### PR TITLE
use pathlib.Path and tempfile.TemporaryDirectory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ extension-pkg-whitelist = "netifaces"
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # raise-missing-from - we use this in order to avoid too generic exception to the user
 # too-many-* - are not enforced for the sake of readability
@@ -39,7 +38,6 @@ extension-pkg-whitelist = "netifaces"
 # fixme - TODO
 disable = [
   "format",
-  "abstract-class-little-used",
   "abstract-method",
   "cyclic-import",
   "duplicate-code",

--- a/test/zip/test_extractor.py
+++ b/test/zip/test_extractor.py
@@ -1,5 +1,4 @@
 import os
-from os.path import exists
 
 from xknxproject.zip import KNXProjExtractor
 
@@ -21,10 +20,10 @@ def test_extract_protected_knx_project_ets5():
     reader = KNXProjExtractor(xknx_test_project_protected_ets5, "test")
     reader.extract()
 
-    assert exists(reader.extraction_path + "P-0242/project.xml")
+    assert reader.extraction_path.joinpath("P-0242/project.xml").exists()
 
     reader.cleanup()
-    assert not exists(reader.extraction_path + "P-0242/project.xml")
+    assert not reader.extraction_path.joinpath("P-0242/project.xml").exists()
 
 
 def test_extract_knx_project_ets5():
@@ -32,10 +31,10 @@ def test_extract_knx_project_ets5():
     reader = KNXProjExtractor(xknx_test_project_protected_ets5, "test")
     reader.extract()
 
-    assert exists(reader.extraction_path + "P-0242/project.xml")
+    assert reader.extraction_path.joinpath("P-0242/project.xml").exists()
 
     reader.cleanup()
-    assert not exists(reader.extraction_path + "P-0242/project.xml")
+    assert not reader.extraction_path.joinpath("P-0242/project.xml").exists()
 
 
 def test_ets6_password_generation():
@@ -57,6 +56,8 @@ def test_extract_protected_knx_project_ets6():
     reader = KNXProjExtractor(xknx_test_project_protected_ets6, "test")
     reader.extract()
     assert reader.get_project_id() == "P-04BF"
-    assert exists(reader.extraction_path + reader.get_project_id() + "/project.xml")
+    assert reader.extraction_path.joinpath(
+        reader.get_project_id(), "project.xml"
+    ).exists()
     reader.cleanup()
-    assert not exists(reader.extraction_path + "P-04BF/project.xml")
+    assert not reader.extraction_path.joinpath("P-04BF/project.xml").exists()

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -1,4 +1,5 @@
 """Application Program Loader."""
+from pathlib import Path
 from typing import Any
 
 from lxml.etree import iterparse  # pylint: disable=no-name-in-module
@@ -16,7 +17,7 @@ class ApplicationProgramLoader(XMLLoader):
         """Initialize the ApplicationProgramLoader."""
         self.devices = devices
 
-    async def load(self, extraction_path: str) -> list[Any]:
+    async def load(self, extraction_path: Path) -> list[Any]:
         """Load Hardware mappings and assign to devices."""
         application_programs: dict[
             str, list[DeviceInstance]
@@ -25,7 +26,7 @@ class ApplicationProgramLoader(XMLLoader):
             com_object_mapping: dict[str, dict[str, str]] = {}
             com_objects: dict[str, ComObject] = {}
             with open(
-                extraction_path + application_program, mode="rb"
+                extraction_path / application_program, mode="rb"
             ) as application_xml:
                 for _, elem in iterparse(application_xml):
                     if elem.tag.endswith("ComObject"):

--- a/xknxproject/loader/group_address_loader.py
+++ b/xknxproject/loader/group_address_loader.py
@@ -1,4 +1,5 @@
 """Group Address Loader."""
+from pathlib import Path
 from xml.dom.minidom import Document, parseString
 
 import aiofiles
@@ -16,11 +17,11 @@ class GroupAddressLoader(XMLLoader):
         """Initialize the GroupAddressLoader."""
         self.project_id = project_id
 
-    async def load(self, extraction_path: str) -> list[XMLGroupAddress]:
+    async def load(self, extraction_path: Path) -> list[XMLGroupAddress]:
         """Load Hardware mappings."""
         group_address_list: list[XMLGroupAddress] = []
         async with aiofiles.open(
-            extraction_path + self.project_id + "/0.xml", encoding="utf-8"
+            extraction_path / self.project_id / "0.xml", encoding="utf-8"
         ) as project_xml:
             dom: Document = parseString(await project_xml.read())
             nodes: list[Document] = dom.getElementsByTagName("GroupAddress")

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -1,5 +1,6 @@
 """Hardware Loader."""
-import os
+from pathlib import Path
+from typing import Iterator
 from xml.dom.minidom import Document, parseString
 
 import aiofiles
@@ -13,7 +14,7 @@ from .loader import XMLLoader
 class HardwareLoader(XMLLoader):
     """Load hardware from KNX XML."""
 
-    async def load(self, extraction_path: str) -> list[Hardware]:
+    async def load(self, extraction_path: Path) -> list[Hardware]:
         """Load Hardware mappings."""
         hardware_list: list[Hardware] = []
         for file in self._get_relevant_files(extraction_path):
@@ -39,10 +40,6 @@ class HardwareLoader(XMLLoader):
         return Hardware(identifier, name, text)
 
     @staticmethod
-    def _get_relevant_files(extraction_path: str) -> list[str]:
+    def _get_relevant_files(extraction_path: Path) -> Iterator[Path]:
         """Get all manufactures Hardware.xml in given KNX ZIP file."""
-        return [
-            f"{directory[0]}/Hardware.xml"
-            for directory in os.walk(extraction_path)
-            if os.path.basename(directory[0]).startswith("M-")
-        ]
+        return extraction_path.glob("**/M-*/Hardware.xml")

--- a/xknxproject/loader/loader.py
+++ b/xknxproject/loader/loader.py
@@ -1,5 +1,6 @@
 """XML Loader for knxproj XML model data."""
 import abc
+from pathlib import Path
 from typing import Any
 
 
@@ -7,5 +8,5 @@ class XMLLoader(abc.ABC):
     """XML Loader that handles loading different KNX XML elements."""
 
     @abc.abstractmethod
-    async def load(self, extraction_path: str) -> list[Any]:
+    async def load(self, extraction_path: Path) -> list[Any]:
         """Load via the given loader implementation."""

--- a/xknxproject/loader/location_loader.py
+++ b/xknxproject/loader/location_loader.py
@@ -1,4 +1,5 @@
 """Location Loader."""
+from pathlib import Path
 from xml.dom.minidom import Document, parseString
 
 import aiofiles
@@ -19,11 +20,11 @@ class LocationLoader(XMLLoader):
         for device in devices:
             self.devices[device.identifier] = device.individual_address
 
-    async def load(self, extraction_path: str) -> list[XMLSpace]:
+    async def load(self, extraction_path: Path) -> list[XMLSpace]:
         """Load Location mappings."""
         spaces: list[XMLSpace] = []
         async with aiofiles.open(
-            extraction_path + self.project_id + "/0.xml", encoding="utf-8"
+            extraction_path / self.project_id / "0.xml", encoding="utf-8"
         ) as project_xml:
             dom: Document = parseString(await project_xml.read())
             node: Document = dom.getElementsByTagName("Locations")[0]

--- a/xknxproject/loader/topology_loader.py
+++ b/xknxproject/loader/topology_loader.py
@@ -1,6 +1,7 @@
 """Group Address Loader."""
 from __future__ import annotations
 
+from pathlib import Path
 from xml.dom.minidom import Document, parseString
 
 import aiofiles
@@ -18,11 +19,11 @@ class TopologyLoader(XMLLoader):
         """Initialize the GroupAddressLoader."""
         self.project_id = project_id
 
-    async def load(self, extraction_path: str) -> list[XMLArea]:
+    async def load(self, extraction_path: Path) -> list[XMLArea]:
         """Load Hardware mappings."""
         areas: list[XMLArea] = []
         async with aiofiles.open(
-            extraction_path + self.project_id + "/0.xml", encoding="utf-8"
+            extraction_path / self.project_id / "0.xml", encoding="utf-8"
         ) as project_xml:
             dom: Document = parseString(await project_xml.read())
             node: Document = dom.getElementsByTagName("Topology")[0]


### PR DESCRIPTION
Use pathlib.Path for path definitions and tempfile.TemporaryDirectory to create a temporary directory for unzipping. 

I'll address the pylint error (`consider-using-with`) from `TemporaryDirectory` in another PR - so the extractor can be used only as context manager.

closes #36 