### PR TITLE
Use ElementTree instead of lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ Caution: Loading a middle-sized project with this tool takes about 1.5 seconds. 
 
 `pip install xknxproject`
 
-In order to parse XML and to overcome the performance issues that parsing application programs with over 800k lines of XML has we use `lxml`.
-`lxml` requires libxml2 to be installed in the underlying system. You can read more on their documentation on this topic.
-
 ## Usage
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ combine_as_imports = true
 [tool.mypy]
 python_version = "3.9"
 strict = true
+show_error_codes = true
 ignore_missing_imports = true
 implicit_reexport = true
 warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ warn_unreachable = true
 ignore = "test"
 persistent = "no"
 reports = "no"
-extension-pkg-whitelist = "lxml"
 
 [tool.pylint.message_control]
 # Reasons disabled:

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,3 +1,2 @@
 cryptography==37.0.4
 pyzipper==0.3.6
-lxml==4.9.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(
 ) as fp:
     exec(fp.read(), VERSION)
 
-REQUIRES = ["cryptography>=35.0.0", "pyzipper>=0.3.5", "aiofiles>=0.8.0", "lxml>=4.8.0"]
+REQUIRES = ["cryptography>=35.0.0", "pyzipper>=0.3.5"]
 
 setup(
     name="xknxproject",

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -1,7 +1,6 @@
 """Application Program Loader."""
+from xml.etree import ElementTree
 from zipfile import Path
-
-from lxml import etree
 
 from xknxproject.models import ComObject, DeviceInstance
 from xknxproject.util import parse_dpt_types
@@ -16,7 +15,7 @@ class ApplicationProgramLoader:
         com_object_mapping: dict[str, dict[str, str]] = {}
         com_objects: dict[str, ComObject] = {}
         with application_program_path.open(mode="rb") as application_xml:
-            for _, elem in etree.iterparse(application_xml):
+            for _, elem in ElementTree.iterparse(application_xml):
                 if elem.tag.endswith("ComObject"):
                     com_objects[elem.get("Id", "")] = ComObject(
                         identifier=elem.get("Id"),
@@ -56,7 +55,7 @@ class ApplicationProgramLoader:
         """Do not load the same application program multiple times."""
         _result: dict[str, list[DeviceInstance]] = {}
         for device in devices:
-            if device.application_program_ref != "":
+            if device.application_program_ref:
                 # zipfile.Path hashes are not equal, therefore we use str to create the struct
                 xml_file_name = device.application_program_xml()
                 _result.setdefault(xml_file_name, []).append(device)

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -1,5 +1,4 @@
 """Application Program Loader."""
-from typing import Any
 from zipfile import Path
 
 from lxml import etree
@@ -11,60 +10,52 @@ from xknxproject.util import parse_dpt_types
 class ApplicationProgramLoader:
     """Load the application program from KNX XML."""
 
-    def __init__(self, devices: list[DeviceInstance]):
-        """Initialize the ApplicationProgramLoader."""
-        self.devices = devices
-
-    def load(self, project_root_path: Path) -> list[Any]:
+    @staticmethod
+    def load(application_program_path: Path, devices: list[DeviceInstance]) -> None:
         """Load Hardware mappings and assign to devices."""
-        application_programs = self._get_optimized_application_program_struct(
-            project_root_path
-        )
-        for application_program_file_path, devices in application_programs.items():
-            com_object_mapping: dict[str, dict[str, str]] = {}
-            com_objects: dict[str, ComObject] = {}
-            with application_program_file_path.open(mode="rb") as application_xml:
-                for _, elem in etree.iterparse(application_xml):
-                    if elem.tag.endswith("ComObject"):
-                        com_objects[elem.get("Id", "")] = ComObject(
-                            identifier=elem.get("Id"),
-                            name=elem.get("Name"),
-                            text=elem.get("Text"),
-                            object_size=elem.get("ObjectSize"),
-                            read_flag=elem.get("ReadFlag", False) == "Enabled",
-                            write_flag=elem.get("WriteFlag", False) == "Enabled",
-                            communication_flag=elem.get("CommunicationFlag", False)
-                            == "Enabled",
-                            transmit_flag=elem.get("TransmitFlag", False) == "Enabled",
-                            update_flag=elem.get("UpdateFlag", False) == "Enabled",
-                            read_on_init_flag=elem.get("ReadOnInitFlag", False)
-                            == "Enabled",
-                            datapoint_type=parse_dpt_types(
-                                elem.get("DatapointType", "").split(" ")
-                            ),
-                        )
-                    if elem.tag.endswith("ComObjectRef"):
-                        com_object_mapping[elem.get("Id")] = {
-                            "RefId": elem.get("RefId"),
-                            "FunctionText": elem.get("FunctionText", None),
-                            "DPTType": elem.get("DatapointType", None),
-                            "Text": elem.get("Text", None),
-                        }
-                    elem.clear()
+        com_object_mapping: dict[str, dict[str, str]] = {}
+        com_objects: dict[str, ComObject] = {}
+        with application_program_path.open(mode="rb") as application_xml:
+            for _, elem in etree.iterparse(application_xml):
+                if elem.tag.endswith("ComObject"):
+                    com_objects[elem.get("Id", "")] = ComObject(
+                        identifier=elem.get("Id"),
+                        name=elem.get("Name"),
+                        text=elem.get("Text"),
+                        object_size=elem.get("ObjectSize"),
+                        read_flag=elem.get("ReadFlag", False) == "Enabled",
+                        write_flag=elem.get("WriteFlag", False) == "Enabled",
+                        communication_flag=elem.get("CommunicationFlag", False)
+                        == "Enabled",
+                        transmit_flag=elem.get("TransmitFlag", False) == "Enabled",
+                        update_flag=elem.get("UpdateFlag", False) == "Enabled",
+                        read_on_init_flag=elem.get("ReadOnInitFlag", False)
+                        == "Enabled",
+                        datapoint_type=parse_dpt_types(
+                            elem.get("DatapointType", "").split(" ")
+                        ),
+                    )
+                if elem.tag.endswith("ComObjectRef"):
+                    com_object_mapping[elem.get("Id")] = {
+                        "RefId": elem.get("RefId"),
+                        "FunctionText": elem.get("FunctionText", None),
+                        "DPTType": elem.get("DatapointType", None),
+                        "Text": elem.get("Text", None),
+                    }
+                elem.clear()
 
-                for device in devices:
-                    device.add_com_object_id(com_object_mapping)
-                    device.add_com_objects(com_objects)
+            for device in devices:
+                device.add_com_object_id(com_object_mapping)
+                device.add_com_objects(com_objects)
 
-        return []
-
-    def _get_optimized_application_program_struct(
-        self,
+    @staticmethod
+    def get_application_program_files_for_devices(
         project_root_path: Path,
+        devices: list[DeviceInstance],
     ) -> dict[Path, list[DeviceInstance]]:
         """Do not load the same application program multiple times."""
         _result: dict[str, list[DeviceInstance]] = {}
-        for device in self.devices:
+        for device in devices:
             if device.application_program_ref != "":
                 # zipfile.Path hashes are not equal, therefore we use str to create the struct
                 xml_file_name = device.application_program_xml()

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -10,7 +10,8 @@ from xknxproject.zip import KNXProjContents
 class HardwareLoader:
     """Load hardware from KNX XML."""
 
-    def load(self, project_contents: KNXProjContents) -> list[Hardware]:
+    @staticmethod
+    def load(project_contents: KNXProjContents) -> list[Hardware]:
         """Load Hardware mappings."""
         hardware_list: list[Hardware] = []
 

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -11,18 +11,17 @@ class HardwareLoader:
     """Load hardware from KNX XML."""
 
     @staticmethod
-    def load(project_contents: KNXProjContents) -> list[Hardware]:
+    def load(hardware_file: Path) -> list[Hardware]:
         """Load Hardware mappings."""
         hardware_list: list[Hardware] = []
 
-        for xml_file in HardwareLoader._get_relevant_files(project_contents):
-            with xml_file.open(mode="rb") as hardware_xml:
-                for _, elem in etree.iterparse(hardware_xml, tag="{*}Manufacturer"):
-                    for hardware in elem.find("{*}Hardware"):
-                        hardware_list.append(
-                            HardwareLoader.parse_hardware_element(hardware)
-                        )
-                    elem.clear()
+        with hardware_file.open(mode="rb") as hardware_xml:
+            for _, elem in etree.iterparse(hardware_xml, tag="{*}Manufacturer"):
+                for hardware in elem.find("{*}Hardware"):
+                    hardware_list.append(
+                        HardwareLoader.parse_hardware_element(hardware)
+                    )
+                elem.clear()
 
         return hardware_list
 
@@ -37,7 +36,7 @@ class HardwareLoader:
         return Hardware(identifier, name, text)
 
     @staticmethod
-    def _get_relevant_files(project_contents: KNXProjContents) -> list[Path]:
+    def get_hardware_files(project_contents: KNXProjContents) -> list[Path]:
         """Get all manufactures Hardware.xml in given KNX ZIP file."""
         # M-*/Hardware.xml
         manufacturer_dirs = [

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -1,9 +1,7 @@
 """Project file loader."""
 from __future__ import annotations
 
-from copy import copy
-
-from lxml import etree
+from xml.etree import ElementTree
 
 from xknxproject.models import (
     ComObjectInstanceRef,
@@ -29,27 +27,29 @@ class ProjectLoader:
     ]:
         """Load topology mappings."""
         areas: list[XMLArea] = []
+        devices: list[DeviceInstance] = []
         group_address_list: list[XMLGroupAddress] = []
+        spaces: list[XMLSpace] = []
 
         with knx_proj_contents.open_project_0() as project_file:
-            for _, elem in etree.iterparse(
-                project_file, tag=("{*}GroupAddress", "{*}Topology", "{*}Locations")
+            tree = ElementTree.parse(project_file)
+            for ga_element in tree.findall(".//{*}GroupAddress"):
+                group_address_list.append(
+                    _GroupAddressLoader.load(group_address_element=ga_element),
+                )
+            for topology_element in tree.findall(
+                "{*}Project/{*}Installations/{*}Installation/{*}Topology"
             ):
-                if elem.tag.endswith("GroupAddress"):
-                    group_address_list.append(
-                        _GroupAddressLoader.load(group_address_element=elem)
-                    )
-                elif elem.tag.endswith("Topology"):
-                    areas = _TopologyLoader.load(topology_element=elem)
-                elif elem.tag.endswith("Locations"):
-                    _topology_element = copy(elem)
-                elem.clear()
-
-        devices = []
-        for area in areas:
-            for line in area.lines:
-                devices.extend(line.devices)
-        spaces = _LocationLoader(devices).load(topology_element=_topology_element)
+                areas.extend(
+                    _TopologyLoader.load(topology_element=topology_element),
+                )
+            for area in areas:
+                for line in area.lines:
+                    devices.extend(line.devices)
+            for location_element in tree.findall(".//{*}Locations"):
+                spaces.extend(
+                    _LocationLoader(devices).load(location_element=location_element),
+                )
 
         return group_address_list, areas, devices, spaces
 
@@ -58,13 +58,13 @@ class _GroupAddressLoader:
     """Load GroupAddress info from KNX XML."""
 
     @staticmethod
-    def load(group_address_element: etree.Element) -> XMLGroupAddress:
+    def load(group_address_element: ElementTree.Element) -> XMLGroupAddress:
         """Load GroupAddress mappings."""
 
         return XMLGroupAddress(
-            name=group_address_element.get("Name"),
-            identifier=group_address_element.get("Id"),
-            address=group_address_element.get("Address"),
+            name=group_address_element.get("Name", ""),
+            identifier=group_address_element.get("Id", ""),
+            address=group_address_element.get("Address", ""),
             dpt_type=group_address_element.get("DatapointType"),
         )
 
@@ -73,7 +73,7 @@ class _TopologyLoader:
     """Load topology from KNX XML."""
 
     @staticmethod
-    def load(topology_element: etree.Element) -> list[XMLArea]:
+    def load(topology_element: ElementTree.Element) -> list[XMLArea]:
         """Load topology mappings."""
         areas: list[XMLArea] = []
 
@@ -83,11 +83,11 @@ class _TopologyLoader:
         return areas
 
     @staticmethod
-    def _create_area(area_element: etree.Element) -> XMLArea:
+    def _create_area(area_element: ElementTree.Element) -> XMLArea:
         """Create an Area."""
-        address: int = int(area_element.get("Address"))
-        name: str = area_element.get("Name")
-        description: str = area_element.get("Description")
+        address: int = int(area_element.get("Address", ""))
+        name: str = area_element.get("Name", "")
+        description: str | None = area_element.get("Description")
         area: XMLArea = XMLArea(address, name, description, [])
 
         for line_element in area_element:
@@ -96,19 +96,19 @@ class _TopologyLoader:
         return area
 
     @staticmethod
-    def _create_line(line_element: etree.Element, area: XMLArea) -> XMLLine:
+    def _create_line(line_element: ElementTree.Element, area: XMLArea) -> XMLLine:
         """Create a Line."""
-        address: int = int(line_element.get("Address"))
-        name: str = line_element.get("Name")
-        description: str = line_element.get("Description")
+        address: int = int(line_element.get("Address", ""))
+        name: str = line_element.get("Name", "")
+        description: str | None = line_element.get("Description")
         if (segment := line_element.find("{*}Segment")) is not None:
             #  ETS-6 (21) adds "Segment" tags between "Line" and "DeviceInstance" tags
-            medium_type = segment.get("MediumTypeRefId")
+            medium_type = segment.get("MediumTypeRefId", "")
         else:
-            medium_type = line_element.get("MediumTypeRefId")
+            medium_type = line_element.get("MediumTypeRefId", "")
         line: XMLLine = XMLLine(address, description, name, medium_type, [], area)
 
-        for device_element in line_element.iterdescendants(tag="{*}DeviceInstance"):
+        for device_element in line_element.findall(".//{*}DeviceInstance"):
             if device := _TopologyLoader._create_device(device_element, line):
                 line.devices.append(device)
 
@@ -116,19 +116,19 @@ class _TopologyLoader:
 
     @staticmethod
     def _create_device(
-        device_element: etree.Element, line: XMLLine
+        device_element: ElementTree.Element, line: XMLLine
     ) -> DeviceInstance | None:
         """Create device."""
-        identifier: str = device_element.get("Id")
+        identifier: str = device_element.get("Id", "")
         address: str | None = device_element.get("Address")
 
         #  devices like power supplies do usually not have an IA.
         if address is None:
             return None
 
-        name: str = device_element.get("Name")
-        last_modified: str = device_element.get("LastModified")
-        hardware_parts = device_element.get("Hardware2ProgramRefId").split("_")
+        name: str = device_element.get("Name", "")
+        last_modified: str = device_element.get("LastModified", "")
+        hardware_parts = device_element.get("Hardware2ProgramRefId", "").split("_")
         hardware_program_ref: str = hardware_parts[0] + "_" + hardware_parts[1]
         device: DeviceInstance = DeviceInstance(
             identifier=identifier,
@@ -143,7 +143,8 @@ class _TopologyLoader:
         for sub_node in device_element:
             if sub_node.tag.endswith("AdditionalAddresses"):
                 for address_node in sub_node:
-                    device.add_additional_address(address_node.get("Address"))
+                    if _address := address_node.get("Address"):
+                        device.additional_addresses.append(_address)
             if sub_node.tag.endswith("ComObjectInstanceRefs"):
                 for com_object in sub_node:
                     if instance := _TopologyLoader._create_com_object_instance(
@@ -155,18 +156,18 @@ class _TopologyLoader:
                     param_instance_ref := sub_node.find("{*}ParameterInstanceRef")
                 ) is not None:
                     device.application_program_ref = param_instance_ref.get(
-                        "RefId"
+                        "RefId", ""
                     ).split("_")[1]
 
         return device
 
     @staticmethod
     def _create_com_object_instance(
-        com_object: etree.Element,
+        com_object: ElementTree.Element,
     ) -> ComObjectInstanceRef | None:
         """Create ComObjectInstanceRef."""
-        ref_id: str = com_object.get("RefId")
-        text: str = com_object.get("Text")
+        ref_id: str = com_object.get("RefId", "")
+        text: str | None = com_object.get("Text")
         dpt_type: str = com_object.get("DatapointType", "")
         links: str | None = com_object.get("Links")
 
@@ -187,15 +188,15 @@ class _LocationLoader:
             device.identifier: device.individual_address for device in devices
         }
 
-    def load(self, topology_element: etree.Element) -> list[XMLSpace]:
+    def load(self, location_element: ElementTree.Element) -> list[XMLSpace]:
         """Load Location mappings."""
         return [
-            self.parse_space(space) for space in topology_element.findall("{*}Space")
+            self.parse_space(space) for space in location_element.findall("{*}Space")
         ]
 
-    def parse_space(self, node: etree.Element) -> XMLSpace:
+    def parse_space(self, node: ElementTree.Element) -> XMLSpace:
         """Parse a space from the document."""
-        name: str = node.get("Name")
+        name: str = node.get("Name", "")
         space_type = SpaceType(node.get("Type"))
         space: XMLSpace = XMLSpace([], space_type, name, [])
 
@@ -204,7 +205,7 @@ class _LocationLoader:
                 # recursively call parse space since this can be nested for an unbound time in the XSD
                 space.spaces.append(self.parse_space(sub_node))
             elif sub_node.tag.endswith("DeviceInstanceRef"):
-                if individual_address := self.devices.get(sub_node.get("RefId")):
+                if individual_address := self.devices.get(sub_node.get("RefId", "")):
                     space.devices.append(individual_address)
 
         return space

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -33,7 +33,10 @@ class ProjectLoader:
 
         with knx_proj_contents.open_project_0() as project_file:
             tree = ElementTree.parse(project_file)
-            for ga_element in tree.findall(".//{*}GroupAddress"):
+            for ga_element in tree.findall(
+                # `//` to ignore <GroupRange> tags to support different GA level formats
+                "{*}Project/{*}Installations/{*}Installation/{*}GroupAddresses//{*}GroupAddress"
+            ):
                 group_address_list.append(
                     _GroupAddressLoader.load(group_address_element=ga_element),
                 )
@@ -46,7 +49,9 @@ class ProjectLoader:
             for area in areas:
                 for line in area.lines:
                     devices.extend(line.devices)
-            for location_element in tree.findall(".//{*}Locations"):
+            for location_element in tree.findall(
+                "{*}Project/{*}Installations/{*}Installation/{*}Locations"
+            ):
                 spaces.extend(
                     _LocationLoader(devices).load(location_element=location_element),
                 )

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -1,4 +1,6 @@
 """Define output type for parsed KNX project."""
+from __future__ import annotations
+
 from typing import Any, Optional, TypedDict
 
 
@@ -16,7 +18,7 @@ class Flags(TypedDict):
 class GroupAddressAssignment(TypedDict):
     """Group address assignments dictionary."""
 
-    co_name: str
+    co_name: str | None
     dpt_type: dict[str, int]
     group_address_links: list[str]
     flags: Flags
@@ -38,7 +40,7 @@ class Line(TypedDict):
 
     name: str
     medium_type: str
-    description: str
+    description: str | None
     devices: list[str]
 
 
@@ -46,7 +48,7 @@ class Area(TypedDict):
     """Area typed dict."""
 
     name: str
-    description: str
+    description: str | None
     lines: dict[str, Line]
 
 
@@ -57,7 +59,7 @@ class GroupAddress(TypedDict):
     identifier: str
     raw_address: int
     address: str
-    dpt_type: Optional[dict[str, int]]
+    dpt_type: dict[str, int] | None
 
 
 class Space(TypedDict):

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -1,7 +1,7 @@
 """Define output type for parsed KNX project."""
 from __future__ import annotations
 
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 
 class Flags(TypedDict):

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -39,7 +39,7 @@ class XMLArea:
 
     address: int
     name: str
-    description: str
+    description: str | None
     lines: list[XMLLine]
 
 
@@ -48,7 +48,7 @@ class XMLLine:
     """Class that represents a Line."""
 
     address: int
-    description: str
+    description: str | None
     name: str
     medium_type: str
     devices: list[DeviceInstance]
@@ -129,7 +129,7 @@ class ComObjectInstanceRef:
     """Class that represents a ComObjectInstanceRef instance."""
 
     ref_id: str
-    text: str
+    text: str | None
     links: list[str]
     data_point_type: dict[str, int]
     com_object_ref: dict[str, str] | None = None

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -124,7 +124,14 @@ class XMLParser:
             self.devices,
             self.spaces,
         ) = ProjectLoader.load(self.knx_proj_contents)
-        self.hardware = HardwareLoader.load(self.knx_proj_contents)
+
+        for _hardware in [
+            HardwareLoader.load(hardware_file)
+            for hardware_file in HardwareLoader.get_hardware_files(
+                self.knx_proj_contents
+            )
+        ]:
+            self.hardware.extend(_hardware)
 
         application_programs = (
             ApplicationProgramLoader.get_application_program_files_for_devices(

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -124,10 +124,15 @@ class XMLParser:
             self.devices,
             self.spaces,
         ) = ProjectLoader.load(self.knx_proj_contents)
-        self.hardware = HardwareLoader().load(self.knx_proj_contents)
+        self.hardware = HardwareLoader.load(self.knx_proj_contents)
 
-        application_program_loader = ApplicationProgramLoader(self.devices)
-        application_program_loader.load(self.knx_proj_contents.root_path)
+        application_programs = (
+            ApplicationProgramLoader.get_application_program_files_for_devices(
+                self.knx_proj_contents.root_path, self.devices
+            )
+        )
+        for application_program_file, devices in application_programs.items():
+            ApplicationProgramLoader.load(application_program_file, devices)
 
         for hardware in self.hardware:
             for device in self.devices:

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -133,6 +133,12 @@ class XMLParser:
         ]:
             self.hardware.extend(_hardware)
 
+        for hardware in self.hardware:
+            for device in self.devices:
+                if device.hardware_program_ref == hardware.identifier:
+                    device.product_name = hardware.name
+                    device.hardware_name = hardware.product_name
+
         application_programs = (
             ApplicationProgramLoader.get_application_program_files_for_devices(
                 self.knx_proj_contents.root_path, self.devices
@@ -140,9 +146,3 @@ class XMLParser:
         )
         for application_program_file, devices in application_programs.items():
             ApplicationProgramLoader.load(application_program_file, devices)
-
-        for hardware in self.hardware:
-            for device in self.devices:
-                if device.hardware_program_ref == hardware.identifier:
-                    device.product_name = hardware.name
-                    device.hardware_name = hardware.product_name


### PR DESCRIPTION
This saves even more memory (on my personal project now 16.6 instead of 18.8 MB) and is slightly faster (1.49 sec).
We can also remove a dependency as ElementTree is in Pythons standard library.

Some adaptions to the models and attribute extraction had to be made as `Element.get()` returns `Optional[str]` (instead of lxml's `etree.Element.get()` which returned `Any`).