### PR TITLE
Load all/correct application program for each device

### DIFF
--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -1,4 +1,6 @@
 """Hardware Loader."""
+from __future__ import annotations
+
 from xml.etree import ElementTree
 from zipfile import Path
 
@@ -28,8 +30,19 @@ class HardwareLoader:
         name: str = hardware_node.get("Name", "")
         _product_node = hardware_node.find(".//{*}Product")
         text: str = _product_node.get("Text", "") if _product_node is not None else ""
+        application_program_ref: dict[str, str] = {}
+        for hardware2program_element in hardware_node.findall(
+            ".//{*}Hardware2Programs/{*}Hardware2Program[@Id]/{*}ApplicationProgramRef[@RefId]/.."
+        ):
+            application_program_ref[
+                hardware2program_element.get("Id")  # type: ignore[index]
+            ] = hardware2program_element.find(
+                "{*}ApplicationProgramRef"
+            ).get(  # type: ignore[union-attr]
+                "RefId"
+            )  # type: ignore[assignment]
 
-        return Hardware(identifier, name, text)
+        return Hardware(identifier, name, text, application_program_ref)
 
     @staticmethod
     def get_hardware_files(project_contents: KNXProjContents) -> list[Path]:

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -133,16 +133,18 @@ class _TopologyLoader:
 
         name: str = device_element.get("Name", "")
         last_modified: str = device_element.get("LastModified", "")
-        hardware_parts = device_element.get("Hardware2ProgramRefId", "").split("_")
-        hardware_program_ref: str = hardware_parts[0] + "_" + hardware_parts[1]
+        _product_ref_parts = device_element.get("ProductRefId", "").split("_")
+        hardware_ref = _product_ref_parts[0] + "_" + _product_ref_parts[1]
+        hardware_program_ref = device_element.get("Hardware2ProgramRefId", "")
         device: DeviceInstance = DeviceInstance(
             identifier=identifier,
             address=address,
             name=name,
             last_modified=last_modified,
+            hardware_ref=hardware_ref,
             hardware_program_ref=hardware_program_ref,
             line=line,
-            manufacturer=hardware_parts[0],
+            manufacturer=_product_ref_parts[0],
         )
 
         for sub_node in device_element:
@@ -156,13 +158,6 @@ class _TopologyLoader:
                         com_object
                     ):
                         device.com_object_instance_refs.append(instance)
-            if sub_node.tag.endswith("ParameterInstanceRefs"):
-                if (
-                    param_instance_ref := sub_node.find("{*}ParameterInstanceRef")
-                ) is not None:
-                    device.application_program_ref = param_instance_ref.get(
-                        "RefId", ""
-                    ).split("_")[1]
 
         return device
 

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -65,6 +65,7 @@ class DeviceInstance:
         address: str,
         name: str,
         last_modified: str,
+        hardware_ref: str,
         hardware_program_ref: str,
         line: XMLLine,
         manufacturer: str,
@@ -77,13 +78,14 @@ class DeviceInstance:
         self.address = address
         self.name = name
         self.last_modified = last_modified
+        self.hardware_ref = hardware_ref
         self.hardware_program_ref = hardware_program_ref
         self.line = line
         self.manufacturer = manufacturer
         self.additional_addresses = additional_addresses or []
         self.com_object_instance_refs = com_object_instance_refs or []
         self.com_objects = com_objects or []
-        self.application_program_ref: str = ""
+        self.application_program_ref: str | None = None
 
         self.individual_address = (
             f"{self.line.area.address}.{self.line.address}.{self.address}"
@@ -118,10 +120,7 @@ class DeviceInstance:
 
     def application_program_xml(self) -> str:
         """Obtain the file name to the application program XML."""
-        return (
-            f"{self.manufacturer}/"
-            f"{self.manufacturer}_{self.application_program_ref}.xml"
-        )
+        return f"{self.manufacturer}/{self.application_program_ref}.xml"
 
 
 @dataclasses.dataclass
@@ -169,3 +168,6 @@ class Hardware:
     identifier: str
     name: str
     product_name: str
+    application_program_ref: dict[
+        str, str
+    ]  # {Hardware2ProgramRefID: ApplicationProgramRef}

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -135,9 +135,14 @@ class XMLParser:
 
         for hardware in self.hardware:
             for device in self.devices:
-                if device.hardware_program_ref == hardware.identifier:
+                if device.hardware_ref == hardware.identifier:
                     device.product_name = hardware.name
                     device.hardware_name = hardware.product_name
+                    device.application_program_ref = (
+                        hardware.application_program_ref.get(
+                            device.hardware_program_ref
+                        )
+                    )
 
         application_programs = (
             ApplicationProgramLoader.get_application_program_files_for_devices(


### PR DESCRIPTION
Previously we used `ParameterInstanceRefs` to construct a `ApplicationProgramRefID` (filename). This was not always correct, and some DeviceInstances had no ParameterInstanceRefs.

Closes #14