### PR TITLE
Skip parsing unused tags from application programs

### DIFF
--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -78,6 +78,10 @@ class ApplicationProgramLoader:
                             ),
                             datapoint_type=datapoint_type,
                         )
+                if elem.tag.endswith("Static"):
+                    # we don't need anything after Static tag (Dynamic, Languages)
+                    elem.clear()
+                    break
                 elem.clear()
 
             for com_instance in com_object_instance_refs:


### PR DESCRIPTION
This speeds up parsing my personal project from 1.61 to 0.64 seconds 🚀 

We currently only need `ComObject` and `ComObjectRef`. Both are children of the `Static` tag - so when the end of that tag is reached we may close the file.