### PR TITLE
Store communication objects in root key and link to them from group addresses and devices

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,6 +11,9 @@ def assert_stub(to_be_verified: KNXProject, stub_name: str) -> None:
 
     with open(stub_path, encoding="utf-8") as stub_file:
         stub = json.load(stub_file)
-        assert stub["topology"] == to_be_verified["topology"]
-        assert stub["group_addresses"] == to_be_verified["group_addresses"]
-        assert stub["devices"] == to_be_verified["devices"]
+        for key, value in stub.items():
+            assert key in to_be_verified, f"`{key}` key missing in generated object"
+            assert value == to_be_verified[key], f"`{key}` item does not match"
+
+        for key in to_be_verified.keys():
+            assert key in stub, f"`{key}` key of generated object missing in stub"

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -1,5 +1,105 @@
 {
-  "version": "0.0.1",
+  "version": "1.1.0",
+  "communication_objects": {
+    "M-0002_A-A066-14-550B_O-40_R-1433": {
+      "name": "Ausgang B",
+      "device_address": "1.1.5",
+      "dpt_type": {},
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-6"]
+    },
+    "M-0002_A-A066-14-550B_O-41_R-1434": {
+      "name": "Ausgang B",
+      "device_address": "1.1.5",
+      "dpt_type": {},
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-5"]
+    },
+    "M-0002_A-A066-14-550B_O-70_R-1505": {
+      "name": "Ausgang C",
+      "device_address": "1.1.5",
+      "dpt_type": { "main": 1, "sub": 8 },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-4"]
+    },
+    "M-0002_A-A066-14-550B_O-71_R-1506": {
+      "name": "Ausgang C",
+      "device_address": "1.1.5",
+      "dpt_type": { "main": 1, "sub": 8 },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-3"]
+    },
+    "M-0002_A-A066-14-550B_O-100_R-1577": {
+      "name": "Ausgang D",
+      "device_address": "1.1.5",
+      "dpt_type": {},
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-2"]
+    },
+    "M-0002_A-A066-14-550B_O-101_R-1578": {
+      "name": "Ausgang D",
+      "device_address": "1.1.5",
+      "dpt_type": { "main": 1, "sub": 8 },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-1"]
+    },
+    "M-0002_A-A066-14-550B_O-4_R-1417": {
+      "name": "Ausgang A-X",
+      "device_address": "1.1.5",
+      "dpt_type": { "main": 1, "sub": 1 },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": true,
+        "read_on_init": false,
+        "transmit": true
+      },
+      "group_address_links": ["GA-7"]
+    }
+  },
   "topology": {
     "0": {
       "name": "Backbone Bereich",
@@ -39,7 +139,7 @@
       "description": "SCN-IP100.03 IP Router with Secure",
       "individual_address": "1.1.0",
       "manufacturer_name": "MDT technologies",
-      "communication_objects": []
+      "communication_object_ids": []
     },
     "1.1.5": {
       "name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
@@ -47,150 +147,76 @@
       "description": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "individual_address": "1.1.5",
       "manufacturer_name": "ABB",
-      "communication_objects": [
-        {
-          "name": "Ausgang B",
-          "dpt_type": {},
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-6"]
-        },
-        {
-          "name": "Ausgang B",
-          "dpt_type": {},
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-5"]
-        },
-        {
-          "name": "Ausgang C",
-          "dpt_type": { "main": 1, "sub": 8 },
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-4"]
-        },
-        {
-          "name": "Ausgang C",
-          "dpt_type": { "main": 1, "sub": 8 },
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-3"]
-        },
-        {
-          "name": "Ausgang D",
-          "dpt_type": {},
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-2"]
-        },
-        {
-          "name": "Ausgang D",
-          "dpt_type": { "main": 1, "sub": 8 },
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": false,
-            "read_on_init": false,
-            "transmit": false
-          },
-          "group_address_links": ["GA-1"]
-        },
-        {
-          "name": "Ausgang A-X",
-          "dpt_type": { "main": 1, "sub": 1 },
-          "flags": {
-            "read": false,
-            "write": true,
-            "communication": true,
-            "update": true,
-            "read_on_init": false,
-            "transmit": true
-          },
-          "group_address_links": ["GA-7"]
-        }
+      "communication_object_ids": [
+        "M-0002_A-A066-14-550B_O-40_R-1433",
+        "M-0002_A-A066-14-550B_O-41_R-1434",
+        "M-0002_A-A066-14-550B_O-70_R-1505",
+        "M-0002_A-A066-14-550B_O-71_R-1506",
+        "M-0002_A-A066-14-550B_O-100_R-1577",
+        "M-0002_A-A066-14-550B_O-101_R-1578",
+        "M-0002_A-A066-14-550B_O-4_R-1417"
       ]
     }
   },
   "group_addresses": {
     "GA-1": {
+      "address": "1/0/0",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-101_R-1578"],
       "name": "Test",
       "identifier": "GA-1",
       "raw_address": 2048,
-      "address": "1/0/0",
       "dpt_type": null
     },
     "GA-2": {
+      "address": "1/0/1",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-100_R-1577"],
       "name": "Behang D auf/ab",
       "identifier": "GA-2",
       "raw_address": 2049,
-      "address": "1/0/1",
       "dpt_type": null
     },
     "GA-3": {
+      "address": "1/0/2",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-71_R-1506"],
       "name": "Lamelle C auf/ab",
       "identifier": "GA-3",
       "raw_address": 2050,
-      "address": "1/0/2",
       "dpt_type": null
     },
     "GA-4": {
+      "address": "1/0/3",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-70_R-1505"],
       "name": "Behang C auf/ab",
       "identifier": "GA-4",
       "raw_address": 2051,
-      "address": "1/0/3",
       "dpt_type": null
     },
     "GA-5": {
+      "address": "1/0/4",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-41_R-1434"],
       "name": "Lamelle B auf/ab",
       "identifier": "GA-5",
       "raw_address": 2052,
-      "address": "1/0/4",
       "dpt_type": null
     },
     "GA-6": {
+      "address": "1/0/5",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-40_R-1433"],
       "name": "BehangB auf/ab",
       "identifier": "GA-6",
       "raw_address": 2053,
-      "address": "1/0/5",
       "dpt_type": null
     },
     "GA-7": {
+      "address": "2/0/6",
+      "communication_object_ids": ["M-0002_A-A066-14-550B_O-4_R-1417"],
       "name": "Windalarm",
       "identifier": "GA-7",
       "raw_address": 4102,
-      "address": "2/0/6",
       "dpt_type": null
     }
+  },
+  "locations": {
+    "Test (1)": { "type": "Building", "devices": [], "spaces": {} }
   }
 }

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -39,7 +39,7 @@
       "description": "SCN-IP100.03 IP Router with Secure",
       "individual_address": "1.1.0",
       "manufacturer_name": "MDT technologies",
-      "group_address_assignments": []
+      "communication_objects": []
     },
     "1.1.5": {
       "name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
@@ -47,9 +47,9 @@
       "description": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "individual_address": "1.1.5",
       "manufacturer_name": "ABB",
-      "group_address_assignments": [
+      "communication_objects": [
         {
-          "co_name": "Ausgang B",
+          "name": "Ausgang B",
           "dpt_type": {},
           "flags": {
             "read": false,
@@ -62,7 +62,7 @@
           "group_address_links": ["GA-6"]
         },
         {
-          "co_name": "Ausgang B",
+          "name": "Ausgang B",
           "dpt_type": {},
           "flags": {
             "read": false,
@@ -75,7 +75,7 @@
           "group_address_links": ["GA-5"]
         },
         {
-          "co_name": "Ausgang C",
+          "name": "Ausgang C",
           "dpt_type": { "main": 1, "sub": 8 },
           "flags": {
             "read": false,
@@ -88,7 +88,7 @@
           "group_address_links": ["GA-4"]
         },
         {
-          "co_name": "Ausgang C",
+          "name": "Ausgang C",
           "dpt_type": { "main": 1, "sub": 8 },
           "flags": {
             "read": false,
@@ -101,7 +101,7 @@
           "group_address_links": ["GA-3"]
         },
         {
-          "co_name": "Ausgang D",
+          "name": "Ausgang D",
           "dpt_type": {},
           "flags": {
             "read": false,
@@ -114,7 +114,7 @@
           "group_address_links": ["GA-2"]
         },
         {
-          "co_name": "Ausgang D",
+          "name": "Ausgang D",
           "dpt_type": { "main": 1, "sub": 8 },
           "flags": {
             "read": false,
@@ -127,7 +127,7 @@
           "group_address_links": ["GA-1"]
         },
         {
-          "co_name": "Ausgang A-X",
+          "name": "Ausgang A-X",
           "dpt_type": { "main": 1, "sub": 1 },
           "flags": {
             "read": false,

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -1,10 +1,10 @@
 """Xknxproj models."""
 from .knxproject import (
     Area,
+    CommunicationObject,
     Device,
     Flags,
     GroupAddress,
-    GroupAddressAssignment,
     KNXProject,
     Line,
     Space,
@@ -25,7 +25,7 @@ from .static import MANUFACTURERS, MEDIUM_TYPES, SpaceType
 __all__ = [
     "Area",
     "Line",
-    "GroupAddressAssignment",
+    "CommunicationObject",
     "GroupAddress",
     "Device",
     "Flags",

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -19,6 +19,7 @@ class CommunicationObject(TypedDict):
     """Communication object dictionary."""
 
     name: str | None
+    device_address: str
     dpt_type: dict[str, int]
     group_address_links: list[str]
     flags: Flags
@@ -32,7 +33,7 @@ class Device(TypedDict):
     description: str
     manufacturer_name: str
     individual_address: str
-    communication_objects: list[CommunicationObject]
+    communication_object_ids: list[str]
 
 
 class Line(TypedDict):
@@ -60,6 +61,7 @@ class GroupAddress(TypedDict):
     raw_address: int
     address: str
     dpt_type: dict[str, int] | None
+    communication_object_ids: list[str]
 
 
 class Space(TypedDict):
@@ -74,6 +76,7 @@ class KNXProject(TypedDict):
     """KNXProject typed dictionary."""
 
     version: str
+    communication_objects: dict[str, CommunicationObject]
     devices: dict[str, Device]
     topology: dict[str, Area]
     locations: dict[str, Space]

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -15,10 +15,10 @@ class Flags(TypedDict):
     read_on_init: bool
 
 
-class GroupAddressAssignment(TypedDict):
-    """Group address assignments dictionary."""
+class CommunicationObject(TypedDict):
+    """Communication object dictionary."""
 
-    co_name: str | None
+    name: str | None
     dpt_type: dict[str, int]
     group_address_links: list[str]
     flags: Flags
@@ -32,7 +32,7 @@ class Device(TypedDict):
     description: str
     manufacturer_name: str
     individual_address: str
-    group_address_assignments: list[GroupAddressAssignment]
+    communication_objects: list[CommunicationObject]
 
 
 class Line(TypedDict):

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -194,7 +194,7 @@ class ComObject:
     transmit_flag: bool  # "TransmitFlag" - knx:Enable_t
     update_flag: bool  # "UpdateFlag" - knx:Enable_t
     read_on_init_flag: bool  # "ReadOnInitFlag" - knx:Enable_t
-    datapoint_type: dict[str, int]  # "DataPointType" - knx:IDREFS
+    datapoint_type: dict[str, int] | None  # "DataPointType" - knx:IDREFS - optional
 
 
 @dataclass(frozen=True)

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -7,11 +7,11 @@ from xknxproject.models import (
     MANUFACTURERS,
     MEDIUM_TYPES,
     Area,
+    CommunicationObject,
     Device,
     DeviceInstance,
     Flags,
     GroupAddress,
-    GroupAddressAssignment,
     Hardware,
     KNXProject,
     Line,
@@ -41,12 +41,12 @@ class XMLParser:
 
         devices_dict: dict[str, Device] = {}
         for device in self.devices:
-            group_address_assignments: list[GroupAddressAssignment] = []
+            device_com_objects: list[CommunicationObject] = []
             for com_object in device.com_object_instance_refs:
                 if com_object.links:
-                    group_address_assignments.append(
-                        GroupAddressAssignment(
-                            co_name=com_object.name or com_object.text,
+                    device_com_objects.append(
+                        CommunicationObject(
+                            name=com_object.name or com_object.text,
                             dpt_type=com_object.datapoint_type,  # type: ignore[typeddict-item]
                             flags=Flags(
                                 read=com_object.read_flag,  # type: ignore[typeddict-item]
@@ -66,7 +66,7 @@ class XMLParser:
                 description=device.hardware_name,
                 individual_address=device.individual_address,
                 manufacturer_name=MANUFACTURERS.get(device.manufacturer, "Unknown"),
-                group_address_assignments=group_address_assignments,
+                communication_objects=device_com_objects,
             )
 
         topology_dict: dict[str, Area] = {}


### PR DESCRIPTION
Communication objects can be used from either group addresses or devices.
An example to get a list of communication objects for a specific device:
```py
project: KNXProject
device_ia = "1.1.10"
[project["communication_objects"][com_id] for com_id in project["devices"][device_ia]["communication_object_ids"]]
```