### PR TITLE
Import description for group addresses

### DIFF
--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -165,7 +165,8 @@
       "name": "Test",
       "identifier": "GA-1",
       "raw_address": 2048,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-2": {
       "address": "1/0/1",
@@ -173,7 +174,8 @@
       "name": "Behang D auf/ab",
       "identifier": "GA-2",
       "raw_address": 2049,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-3": {
       "address": "1/0/2",
@@ -181,7 +183,8 @@
       "name": "Lamelle C auf/ab",
       "identifier": "GA-3",
       "raw_address": 2050,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-4": {
       "address": "1/0/3",
@@ -189,7 +192,8 @@
       "name": "Behang C auf/ab",
       "identifier": "GA-4",
       "raw_address": 2051,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-5": {
       "address": "1/0/4",
@@ -197,7 +201,8 @@
       "name": "Lamelle B auf/ab",
       "identifier": "GA-5",
       "raw_address": 2052,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-6": {
       "address": "1/0/5",
@@ -205,7 +210,8 @@
       "name": "BehangB auf/ab",
       "identifier": "GA-6",
       "raw_address": 2053,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     },
     "GA-7": {
       "address": "2/0/6",
@@ -213,7 +219,8 @@
       "name": "Windalarm",
       "identifier": "GA-7",
       "raw_address": 4102,
-      "dpt_type": null
+      "dpt_type": null,
+      "description": ""
     }
   },
   "locations": {

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -71,6 +71,7 @@ class _GroupAddressLoader:
             identifier=group_address_element.get("Id", ""),
             address=group_address_element.get("Address", ""),
             dpt_type=group_address_element.get("DatapointType"),
+            description=group_address_element.get("Description", ""),
         )
 
 

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -62,6 +62,7 @@ class GroupAddress(TypedDict):
     address: str
     dpt_type: dict[str, int] | None
     communication_object_ids: list[str]
+    description: str
 
 
 class Space(TypedDict):

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -11,11 +11,19 @@ from xknxproject.util import parse_dpt_types
 class XMLGroupAddress:
     """Class that represents a group address."""
 
-    def __init__(self, name: str, identifier: str, address: str, dpt_type: str | None):
+    def __init__(
+        self,
+        name: str,
+        identifier: str,
+        address: str,
+        description: str,
+        dpt_type: str | None,
+    ):
         """Initialize a group address."""
         self.name = name
         self.identifier = identifier.split("_")[1]
         self.raw_address = int(address)
+        self.description = description
         self.dpt_type = (
             None if dpt_type is None else parse_dpt_types(dpt_type.split(" "))
         )

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -105,6 +105,7 @@ class XMLParser:
                 address=group_address.address,
                 dpt_type=group_address.dpt_type,
                 communication_object_ids=_com_object_ids,
+                description=group_address.description,
             )
 
         space_dict: dict[str, Space] = {}


### PR DESCRIPTION
Humble addition to include the Description field of group addresses.

This can be useful to use the Description field in ETS to add formatted text that can then be used by an import script to build the hass entities.
 
Example uses of the Description field:
- add a tag to indicate the group address should or not be imported into hass
- add non gaddr parameters, like cover travelling_time_down or travelling_time_up