### PR TITLE
Add all group address links to communication object

### DIFF
--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -49,21 +49,26 @@ class XMLParser:
             device_com_objects: list[str] = []
             for com_object in device.com_object_instance_refs:
                 if com_object.links:
-                    communication_objects[com_object.ref_id] = CommunicationObject(
-                        name=com_object.name or com_object.text,
-                        device_address=device.individual_address,
-                        dpt_type=com_object.datapoint_type,  # type: ignore[typeddict-item]
-                        flags=Flags(
-                            read=com_object.read_flag,  # type: ignore[typeddict-item]
-                            write=com_object.write_flag,  # type: ignore[typeddict-item]
-                            communication=com_object.communication_flag,  # type: ignore[typeddict-item]
-                            update=com_object.update_flag,  # type: ignore[typeddict-item]
-                            read_on_init=com_object.read_on_init_flag,  # type: ignore[typeddict-item]
-                            transmit=com_object.transmit_flag,  # type: ignore[typeddict-item]
-                        ),
-                        group_address_links=com_object.links,
-                    )
-                    device_com_objects.append(com_object.ref_id)
+                    if not com_object.ref_id in communication_objects:
+                        communication_objects[com_object.ref_id] = CommunicationObject(
+                            name=com_object.name or com_object.text,
+                            device_address=device.individual_address,
+                            dpt_type=com_object.datapoint_type,  # type: ignore[typeddict-item]
+                            flags=Flags(
+                                read=com_object.read_flag,  # type: ignore[typeddict-item]
+                                write=com_object.write_flag,  # type: ignore[typeddict-item]
+                                communication=com_object.communication_flag,  # type: ignore[typeddict-item]
+                                update=com_object.update_flag,  # type: ignore[typeddict-item]
+                                read_on_init=com_object.read_on_init_flag,  # type: ignore[typeddict-item]
+                                transmit=com_object.transmit_flag,  # type: ignore[typeddict-item]
+                            ),
+                            group_address_links=com_object.links,
+                        )
+                        device_com_objects.append(com_object.ref_id)
+                    else:
+                        communication_objects[com_object.ref_id][
+                            "group_address_links"
+                        ] += com_object.links
 
             devices_dict[device.individual_address] = Device(
                 name=device.name or device.product_name,

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -49,7 +49,7 @@ class XMLParser:
             device_com_objects: list[str] = []
             for com_object in device.com_object_instance_refs:
                 if com_object.links:
-                    if not com_object.ref_id in communication_objects:
+                    if com_object.ref_id not in communication_objects:
                         communication_objects[com_object.ref_id] = CommunicationObject(
                             name=com_object.name or com_object.text,
                             device_address=device.individual_address,


### PR DESCRIPTION
When using a device like the MDT AKH-0800.03 multiple group addresses are linked to the same internal communication object id. If we export the data only the last group address gets added to the communication object because it got overwritten in each iteration.
This solves this issue and adds all group addresses to the communication object.

Attached you can find the export of a MRE project.

Export the project to and dump it as json:
```python
from xknxproject.models import KNXProject
from xknxproject import XKNXProj
import json


KNX_PROJECT_FILE = "/mnt/d/tmp/blabla.knxproj"

knxproj: XKNXProj = XKNXProj(KNX_PROJECT_FILE)
project: KNXProject = knxproj.parse()

with open("exp.json", "w") as f:
    json.dump(project, f)
```

Current result (only GA4 has communication objects, only GA4 is defined as group address link in the com obj, com obj appears multiple times at the device):
```json
{
    "version": "2.1.0",
    "communication_objects": {
        "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3": {
            "name": "SollWert",
            "device_address": "1.1.1",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "flags": {
                "read": false,
                "write": true,
                "communication": true,
                "update": false,
                "read_on_init": false,
                "transmit": false
            },
            "group_address_links": [
                "GA-4"
            ]
        }
    },
    "topology": {
        "0": {
            "name": "",
            "description": null,
            "lines": {
                "0": {
                    "name": "",
                    "description": null,
                    "devices": [],
                    "medium_type": "KNXnet/IP (IP)"
                }
            }
        },
        "1": {
            "name": "",
            "description": null,
            "lines": {
                "0": {
                    "name": "",
                    "description": null,
                    "devices": [],
                    "medium_type": "KNXnet/IP (IP)"
                },
                "1": {
                    "name": "",
                    "description": null,
                    "devices": [
                        "1.1.1"
                    ],
                    "medium_type": "Twisted Pair (TP)"
                }
            }
        }
    },
    "devices": {
        "1.1.1": {
            "name": "Heizungsaktor 8-fach",
            "product_name": "Heizungsaktor 8-fach",
            "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
            "individual_address": "1.1.1",
            "manufacturer_name": "MDT technologies",
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3",
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3",
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3",
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ]
        }
    },
    "group_addresses": {
        "GA-1": {
            "name": "GA1",
            "identifier": "GA-1",
            "raw_address": 1,
            "address": "0/0/1",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [],
            "description": ""
        },
        "GA-2": {
            "name": "GA2",
            "identifier": "GA-2",
            "raw_address": 2,
            "address": "0/0/2",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [],
            "description": ""
        },
        "GA-3": {
            "name": "GA3",
            "identifier": "GA-3",
            "raw_address": 3,
            "address": "0/0/3",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [],
            "description": ""
        },
        "GA-4": {
            "name": "GA4",
            "identifier": "GA-4",
            "raw_address": 4,
            "address": "0/0/4",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ],
            "description": ""
        }
    },
    "locations": {
        "blabla": {
            "type": "Building",
            "devices": [],
            "spaces": {}
        }
    }
}
```

This version (every GA has a com obj, all GA are added to the com obj, com obj only appears once at the device):
```json
{
    "version": "2.1.0",
    "communication_objects": {
        "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3": {
            "name": "SollWert",
            "device_address": "1.1.1",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "flags": {
                "read": false,
                "write": true,
                "communication": true,
                "update": false,
                "read_on_init": false,
                "transmit": false
            },
            "group_address_links": [
                "GA-1",
                "GA-3",
                "GA-2",
                "GA-4"
            ]
        }
    },
    "topology": {
        "0": {
            "name": "",
            "description": null,
            "lines": {
                "0": {
                    "name": "",
                    "description": null,
                    "devices": [],
                    "medium_type": "KNXnet/IP (IP)"
                }
            }
        },
        "1": {
            "name": "",
            "description": null,
            "lines": {
                "0": {
                    "name": "",
                    "description": null,
                    "devices": [],
                    "medium_type": "KNXnet/IP (IP)"
                },
                "1": {
                    "name": "",
                    "description": null,
                    "devices": [
                        "1.1.1"
                    ],
                    "medium_type": "Twisted Pair (TP)"
                }
            }
        }
    },
    "devices": {
        "1.1.1": {
            "name": "Heizungsaktor 8-fach",
            "product_name": "Heizungsaktor 8-fach",
            "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
            "individual_address": "1.1.1",
            "manufacturer_name": "MDT technologies",
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ]
        }
    },
    "group_addresses": {
        "GA-1": {
            "name": "GA1",
            "identifier": "GA-1",
            "raw_address": 1,
            "address": "0/0/1",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ],
            "description": ""
        },
        "GA-2": {
            "name": "GA2",
            "identifier": "GA-2",
            "raw_address": 2,
            "address": "0/0/2",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ],
            "description": ""
        },
        "GA-3": {
            "name": "GA3",
            "identifier": "GA-3",
            "raw_address": 3,
            "address": "0/0/3",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ],
            "description": ""
        },
        "GA-4": {
            "name": "GA4",
            "identifier": "GA-4",
            "raw_address": 4,
            "address": "0/0/4",
            "dpt_type": {
                "main": 9,
                "sub": 1
            },
            "communication_object_ids": [
                "M-0083_A-013A-32-DCC1_MD-2_O-2-2_R-3"
            ],
            "description": ""
        }
    },
    "locations": {
        "blabla": {
            "type": "Building",
            "devices": [],
            "spaces": {}
        }
    }
}
```

[mre_knx_project.zip](https://github.com/XKNX/xknxproject/files/11115939/mre_knx_project.zip)
