### PR TITLE
Fix coverage source directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-source = ets
+source = xknxproject
 relative_files = True
 
 omit =


### PR DESCRIPTION
`coverage run -m pytest` now works.
Previously it errored with 
> CoverageWarning: Module ets was never imported. (module-not-imported)

Latest PR (#186) had no Codecov comment so I had a look at it. There was an upload, but it is still processing in Codecov.
It seems to have worked fine previously in CI, but I'm not sure why it worked or if this fix changes something about that. 