### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**' # run on all branches
+      - main
   pull_request:
     branches:
       - '**' # run on all branches

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,38 @@
+name: Pre-commit auto-update
+
+on:
+  schedule:
+    - cron: "0 8 15 * *"
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements/production.txt
+            requirements/testing.txt
+            .pre-commit-config.yaml
+      - name: Install dependencies
+        # needed for the mypy hook
+        run: |
+          pip install -r requirements/testing.txt
+      - name: Pre-commit auto-update
+        env:
+          # new branch is created in create-pull-request step
+          SKIP: no-commit-to-branch
+        uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.


### PR DESCRIPTION
- Don't run CI workflow twice on PRs
- Add pre-commit updater workflow

same as we do in `xknx` repo.