### PR TITLE
Use unique keys for communication objects (Module and multiple instance compatibility)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,10 +16,7 @@ exclude_lines =
     raise NotImplementedError
 
     # Don't complain about logs
-    logger.debug
-    logger.info
-    logger.warning
-    logger.error
+    _LOGGER.
 
     # Don't complain about missing debug-only code:
     def __repr__

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -1,0 +1,260 @@
+{
+  "version": "2.1.0",
+  "communication_objects": {
+    "1.1.1/O-334_R-21": {
+      "name": "FuehrungsWert",
+      "device_address": "1.1.1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": true,
+        "read_on_init": false,
+        "transmit": true
+      },
+      "group_address_links": ["GA-3"]
+    },
+    "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1": {
+      "name": "IstWert",
+      "device_address": "1.1.1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": true,
+        "read_on_init": false,
+        "transmit": true
+      },
+      "group_address_links": ["GA-1"]
+    },
+    "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3": {
+      "name": "SollWert",
+      "device_address": "1.1.1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-2", "GA-6"]
+    },
+    "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1": {
+      "name": "IstWert",
+      "device_address": "1.1.1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": true,
+        "read_on_init": false,
+        "transmit": true
+      },
+      "group_address_links": ["GA-7"]
+    },
+    "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3": {
+      "name": "SollWert",
+      "device_address": "1.1.1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": true,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-4", "GA-6"]
+    },
+    "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3": {
+      "name": "SollWert",
+      "device_address": "1.1.2",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "flags": {
+        "read": false,
+        "write": true,
+        "communication": true,
+        "update": false,
+        "read_on_init": false,
+        "transmit": false
+      },
+      "group_address_links": ["GA-5", "GA-6"]
+    }
+  },
+  "topology": {
+    "0": {
+      "name": "Backbone Bereich",
+      "description": null,
+      "lines": {
+        "0": {
+          "name": "Bereichslinie",
+          "description": null,
+          "devices": [],
+          "medium_type": "KNXnet/IP (IP)"
+        }
+      }
+    },
+    "1": {
+      "name": "Neuer Bereich",
+      "description": null,
+      "lines": {
+        "0": {
+          "name": "Hauptlinie",
+          "description": null,
+          "devices": [],
+          "medium_type": "KNXnet/IP (IP)"
+        },
+        "1": {
+          "name": "Neue Linie",
+          "description": null,
+          "devices": ["1.1.1", "1.1.2"],
+          "medium_type": "Twisted Pair (TP)"
+        }
+      }
+    }
+  },
+  "devices": {
+    "1.1.1": {
+      "name": "Heizungsaktor 8-fach",
+      "product_name": "Heizungsaktor 8-fach",
+      "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "individual_address": "1.1.1",
+      "manufacturer_name": "MDT technologies",
+      "communication_object_ids": [
+        "1.1.1/O-334_R-21",
+        "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1",
+        "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3",
+        "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1",
+        "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3"
+      ]
+    },
+    "1.1.2": {
+      "name": "Heizungsaktor 8-fach",
+      "product_name": "Heizungsaktor 8-fach",
+      "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "individual_address": "1.1.2",
+      "manufacturer_name": "MDT technologies",
+      "communication_object_ids": ["1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"]
+    }
+  },
+  "group_addresses": {
+    "GA-1": {
+      "name": "Temperatur Ist",
+      "identifier": "GA-1",
+      "raw_address": 1,
+      "address": "0/0/1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.1/MD-2_M-1_MI-1_O-2-1_R-1"],
+      "description": ""
+    },
+    "GA-2": {
+      "name": "Temperatur Soll",
+      "identifier": "GA-2",
+      "raw_address": 2,
+      "address": "0/0/2",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.1/MD-2_M-1_MI-1_O-2-2_R-3"],
+      "description": ""
+    },
+    "GA-3": {
+      "name": "Reglerwert",
+      "identifier": "GA-3",
+      "raw_address": 3,
+      "address": "0/0/3",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.1/O-334_R-21"],
+      "description": ""
+    },
+    "GA-4": {
+      "name": "Temperatur Soll",
+      "identifier": "GA-4",
+      "raw_address": 258,
+      "address": "0/1/2",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.1/MD-2_M-2_MI-1_O-2-2_R-3"],
+      "description": ""
+    },
+    "GA-7": {
+      "name": "Temperatur Ist",
+      "identifier": "GA-7",
+      "raw_address": 257,
+      "address": "0/1/1",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.1/MD-2_M-2_MI-1_O-2-1_R-1"],
+      "description": ""
+    },
+    "GA-5": {
+      "name": "Temperatur Soll",
+      "identifier": "GA-5",
+      "raw_address": 514,
+      "address": "0/2/2",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": ["1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"],
+      "description": ""
+    },
+    "GA-6": {
+      "name": "Temperatur Soll",
+      "identifier": "GA-6",
+      "raw_address": 1794,
+      "address": "0/7/2",
+      "dpt_type": {
+        "main": 9,
+        "sub": 1
+      },
+      "communication_object_ids": [
+        "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3",
+        "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3",
+        "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"
+      ],
+      "description": ""
+    }
+  },
+  "locations": {
+    "ModuleDefinitionTest": {
+      "type": "Building",
+      "devices": [],
+      "spaces": {}
+    }
+  }
+}

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -1,7 +1,7 @@
 {
   "version": "2.1.0",
   "communication_objects": {
-    "M-0002_A-A066-14-550B_O-40_R-1433": {
+    "1.1.5/O-40_R-1433": {
       "name": "Ausgang B",
       "device_address": "1.1.5",
       "dpt_type": {},
@@ -15,7 +15,7 @@
       },
       "group_address_links": ["GA-6"]
     },
-    "M-0002_A-A066-14-550B_O-41_R-1434": {
+    "1.1.5/O-41_R-1434": {
       "name": "Ausgang B",
       "device_address": "1.1.5",
       "dpt_type": {},
@@ -29,7 +29,7 @@
       },
       "group_address_links": ["GA-5"]
     },
-    "M-0002_A-A066-14-550B_O-70_R-1505": {
+    "1.1.5/O-70_R-1505": {
       "name": "Ausgang C",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
@@ -43,7 +43,7 @@
       },
       "group_address_links": ["GA-4"]
     },
-    "M-0002_A-A066-14-550B_O-71_R-1506": {
+    "1.1.5/O-71_R-1506": {
       "name": "Ausgang C",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
@@ -57,7 +57,7 @@
       },
       "group_address_links": ["GA-3"]
     },
-    "M-0002_A-A066-14-550B_O-100_R-1577": {
+    "1.1.5/O-100_R-1577": {
       "name": "Ausgang D",
       "device_address": "1.1.5",
       "dpt_type": {},
@@ -71,7 +71,7 @@
       },
       "group_address_links": ["GA-2"]
     },
-    "M-0002_A-A066-14-550B_O-101_R-1578": {
+    "1.1.5/O-101_R-1578": {
       "name": "Ausgang D",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
@@ -85,7 +85,7 @@
       },
       "group_address_links": ["GA-1"]
     },
-    "M-0002_A-A066-14-550B_O-4_R-1417": {
+    "1.1.5/O-4_R-1417": {
       "name": "Ausgang A-X",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 1 },
@@ -148,20 +148,20 @@
       "individual_address": "1.1.5",
       "manufacturer_name": "ABB",
       "communication_object_ids": [
-        "M-0002_A-A066-14-550B_O-40_R-1433",
-        "M-0002_A-A066-14-550B_O-41_R-1434",
-        "M-0002_A-A066-14-550B_O-70_R-1505",
-        "M-0002_A-A066-14-550B_O-71_R-1506",
-        "M-0002_A-A066-14-550B_O-100_R-1577",
-        "M-0002_A-A066-14-550B_O-101_R-1578",
-        "M-0002_A-A066-14-550B_O-4_R-1417"
+        "1.1.5/O-40_R-1433",
+        "1.1.5/O-41_R-1434",
+        "1.1.5/O-70_R-1505",
+        "1.1.5/O-71_R-1506",
+        "1.1.5/O-100_R-1577",
+        "1.1.5/O-101_R-1578",
+        "1.1.5/O-4_R-1417"
       ]
     }
   },
   "group_addresses": {
     "GA-1": {
       "address": "1/0/0",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-101_R-1578"],
+      "communication_object_ids": ["1.1.5/O-101_R-1578"],
       "name": "Test",
       "identifier": "GA-1",
       "raw_address": 2048,
@@ -170,7 +170,7 @@
     },
     "GA-2": {
       "address": "1/0/1",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-100_R-1577"],
+      "communication_object_ids": ["1.1.5/O-100_R-1577"],
       "name": "Behang D auf/ab",
       "identifier": "GA-2",
       "raw_address": 2049,
@@ -179,7 +179,7 @@
     },
     "GA-3": {
       "address": "1/0/2",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-71_R-1506"],
+      "communication_object_ids": ["1.1.5/O-71_R-1506"],
       "name": "Lamelle C auf/ab",
       "identifier": "GA-3",
       "raw_address": 2050,
@@ -188,7 +188,7 @@
     },
     "GA-4": {
       "address": "1/0/3",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-70_R-1505"],
+      "communication_object_ids": ["1.1.5/O-70_R-1505"],
       "name": "Behang C auf/ab",
       "identifier": "GA-4",
       "raw_address": 2051,
@@ -197,7 +197,7 @@
     },
     "GA-5": {
       "address": "1/0/4",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-41_R-1434"],
+      "communication_object_ids": ["1.1.5/O-41_R-1434"],
       "name": "Lamelle B auf/ab",
       "identifier": "GA-5",
       "raw_address": 2052,
@@ -206,7 +206,7 @@
     },
     "GA-6": {
       "address": "1/0/5",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-40_R-1433"],
+      "communication_object_ids": ["1.1.5/O-40_R-1433"],
       "name": "BehangB auf/ab",
       "identifier": "GA-6",
       "raw_address": 2053,
@@ -215,7 +215,7 @@
     },
     "GA-7": {
       "address": "2/0/6",
-      "communication_object_ids": ["M-0002_A-A066-14-550B_O-4_R-1417"],
+      "communication_object_ids": ["1.1.5/O-4_R-1417"],
       "name": "Windalarm",
       "identifier": "GA-7",
       "raw_address": 4102,

--- a/test/test_knxproj.py
+++ b/test/test_knxproj.py
@@ -3,11 +3,16 @@ from xknxproject import XKNXProj
 from . import RESOURCES_PATH
 from .conftest import assert_stub
 
-xknx_test_project_protected_ets5 = RESOURCES_PATH / "xknx_test_project.knxproj"
-
 
 def test_parse_project_ets5():
     """Test parsing of ETS5 project."""
-    knxproj = XKNXProj(xknx_test_project_protected_ets5, "test")
+    knxproj = XKNXProj(RESOURCES_PATH / "xknx_test_project.knxproj", "test")
     project = knxproj.parse()
     assert_stub(project, "xknx_test_project.json")
+
+
+def test_parse_project_modules():
+    """Test parsing of ETS5 project including 2 identical devices with module definitions."""
+    knxproj = XKNXProj(RESOURCES_PATH / "module-definition-test.knxproj")
+    project = knxproj.parse()
+    assert_stub(project, "module-definition-test.json")

--- a/test/xml/test_parser.py
+++ b/test/xml/test_parser.py
@@ -56,11 +56,13 @@ def test_parse_project_with_module_defs():
         parser = XMLParser(knx_project_contents)
         parser.parse()
 
-    assert len(parser.group_addresses) == 3
+    assert len(parser.group_addresses) == 7
     assert parser.group_addresses[0].address == "0/0/1"
     assert parser.group_addresses[1].address == "0/0/2"
     assert parser.group_addresses[2].address == "0/0/3"
 
     assert len(parser.areas) == 2
     assert len(parser.areas[1].lines) == 2
-    assert len(parser.areas[1].lines[1].devices) == 1
+    assert len(parser.areas[1].lines[1].devices) == 2
+
+    assert len(parser.devices) == 2

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -12,16 +12,19 @@ class HardwareLoader:
     """Load hardware from KNX XML."""
 
     @staticmethod
-    def load(hardware_file: Path) -> list[Hardware]:
+    def load(hardware_file: Path) -> dict[str, Hardware]:
         """Load Hardware mappings."""
-        hardware_list: list[Hardware] = []
+        hardware_dict: dict[str, Hardware] = {}
 
         with hardware_file.open(mode="rb") as hardware_xml:
             tree = ElementTree.parse(hardware_xml)
-            for hardware in tree.findall(".//{*}Manufacturer/{*}Hardware/{*}Hardware"):
-                hardware_list.append(HardwareLoader.parse_hardware_element(hardware))
+            for hardware_node in tree.findall(
+                ".//{*}Manufacturer/{*}Hardware/{*}Hardware"
+            ):
+                _hardware = HardwareLoader.parse_hardware_element(hardware_node)
+                hardware_dict[_hardware.identifier] = _hardware
 
-        return hardware_list
+        return hardware_dict
 
     @staticmethod
     def parse_hardware_element(hardware_node: ElementTree.Element) -> Hardware:

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -134,16 +134,19 @@ class ComObjectInstanceRef:
     description: str | None  # "Description" - language dependent
     links: list[str] | None  # "Links" - knx:RELIDREFS
 
+    # resolved via Hardware.xml from the containing DeviceInstance
+    com_object_ref_id: str | None = None
+
     # only available form ComObject and ComObjectRef
     name: str | None = None
     number: int | None = None
     object_size: str | None = None
 
-    def update_ref_id(self, application_program_ref: str) -> None:
+    def resolve_com_object_ref_id(self, application_program_ref: str) -> None:
         """Prepend the ref_id with the application program ref."""
         # Remove module and ModuleInstance occurence as they will not be in the application program directly
-        self.ref_id = re.sub(r"(M-\d+?_MI-\d+?_)", "", self.ref_id)
-        self.ref_id = f"{application_program_ref}_{self.ref_id}"
+        ref_id = re.sub(r"(M-\d+?_MI-\d+?_)", "", self.ref_id)
+        self.com_object_ref_id = f"{application_program_ref}_{ref_id}"
 
     def merge_from_application(self, com_object: ComObject | ComObjectRef) -> None:
         """Fill missing information with information parsed from the application program."""

--- a/xknxproject/xknxproj.py
+++ b/xknxproject/xknxproj.py
@@ -1,15 +1,12 @@
 """ETS Project Parser is a library to parse ETS project files."""
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 
 from xknxproject import __version__
 from xknxproject.models import KNXProject
 from xknxproject.xml import XMLParser
 from xknxproject.zip.extractor import extract
-
-logger = logging.getLogger("xknxproject.log")
 
 
 class XKNXProj:


### PR DESCRIPTION
Use device address instead of application ref id as first part of key for communication objects, so similar references eg. from 2 common devices or devices using modules don't overwrite previously parsed communication object.

Closes #189 