### PR TITLE
Preserve text, description and function text of COs

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -3,6 +3,9 @@
   "communication_objects": {
     "1.1.1/O-334_R-21": {
       "name": "FuehrungsWert",
+      "text": "Outside temperature / Reference value",
+      "function_text": "Receive measured value",
+      "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
@@ -20,6 +23,9 @@
     },
     "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1": {
       "name": "IstWert",
+      "text": "Kanal A: Wohnzimmer",
+      "function_text": "Receive temperature value",
+      "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
@@ -37,6 +43,9 @@
     },
     "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "text": "Kanal A: Wohnzimmer",
+      "function_text": "Preset setpoint",
+      "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
@@ -54,6 +63,9 @@
     },
     "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1": {
       "name": "IstWert",
+      "text": "Kanal B: Küche",
+      "function_text": "Receive temperature value",
+      "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
@@ -71,6 +83,9 @@
     },
     "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "text": "Kanal B: Küche",
+      "function_text": "Preset setpoint",
+      "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
@@ -88,6 +103,9 @@
     },
     "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "text": "Kanal A: Bad",
+      "function_text": "Preset setpoint",
+      "description": "",
       "device_address": "1.1.2",
       "dpt_type": {
         "main": 9,

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -3,6 +3,9 @@
   "communication_objects": {
     "1.1.5/O-40_R-1433": {
       "name": "Ausgang B",
+      "text": "Output B",
+      "function_text": "Move blinds/shutter up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
       "flags": {
@@ -17,6 +20,9 @@
     },
     "1.1.5/O-41_R-1434": {
       "name": "Ausgang B",
+      "text": "Output B",
+      "function_text": "Slat adjustm./stop up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
       "flags": {
@@ -31,6 +37,9 @@
     },
     "1.1.5/O-70_R-1505": {
       "name": "Ausgang C",
+      "text": "Output C",
+      "function_text": "Move blinds/shutter up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
       "flags": {
@@ -45,6 +54,9 @@
     },
     "1.1.5/O-71_R-1506": {
       "name": "Ausgang C",
+      "text": "Output C",
+      "function_text": "Slat adjustm./stop up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
       "flags": {
@@ -59,6 +71,9 @@
     },
     "1.1.5/O-100_R-1577": {
       "name": "Ausgang D",
+      "text": "Output D",
+      "function_text": "Move blinds/shutter up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
       "flags": {
@@ -73,6 +88,9 @@
     },
     "1.1.5/O-101_R-1578": {
       "name": "Ausgang D",
+      "text": "Output D",
+      "function_text": "Slat adjustm./stop up-down",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 8 },
       "flags": {
@@ -87,6 +105,9 @@
     },
     "1.1.5/O-4_R-1417": {
       "name": "Ausgang A-X",
+      "text": "Output A-X",
+      "function_text": "Wind alarm no. 1",
+      "description": "",
       "device_address": "1.1.5",
       "dpt_type": { "main": 1, "sub": 1 },
       "flags": {
@@ -160,66 +181,66 @@
   },
   "group_addresses": {
     "GA-1": {
-      "address": "1/0/0",
-      "communication_object_ids": ["1.1.5/O-101_R-1578"],
       "name": "Test",
       "identifier": "GA-1",
       "raw_address": 2048,
+      "address": "1/0/0",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-101_R-1578"],
       "description": ""
     },
     "GA-2": {
-      "address": "1/0/1",
-      "communication_object_ids": ["1.1.5/O-100_R-1577"],
       "name": "Behang D auf/ab",
       "identifier": "GA-2",
       "raw_address": 2049,
+      "address": "1/0/1",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-100_R-1577"],
       "description": ""
     },
     "GA-3": {
-      "address": "1/0/2",
-      "communication_object_ids": ["1.1.5/O-71_R-1506"],
       "name": "Lamelle C auf/ab",
       "identifier": "GA-3",
       "raw_address": 2050,
+      "address": "1/0/2",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-71_R-1506"],
       "description": ""
     },
     "GA-4": {
-      "address": "1/0/3",
-      "communication_object_ids": ["1.1.5/O-70_R-1505"],
       "name": "Behang C auf/ab",
       "identifier": "GA-4",
       "raw_address": 2051,
+      "address": "1/0/3",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-70_R-1505"],
       "description": ""
     },
     "GA-5": {
-      "address": "1/0/4",
-      "communication_object_ids": ["1.1.5/O-41_R-1434"],
       "name": "Lamelle B auf/ab",
       "identifier": "GA-5",
       "raw_address": 2052,
+      "address": "1/0/4",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-41_R-1434"],
       "description": ""
     },
     "GA-6": {
-      "address": "1/0/5",
-      "communication_object_ids": ["1.1.5/O-40_R-1433"],
       "name": "BehangB auf/ab",
       "identifier": "GA-6",
       "raw_address": 2053,
+      "address": "1/0/5",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-40_R-1433"],
       "description": ""
     },
     "GA-7": {
-      "address": "2/0/6",
-      "communication_object_ids": ["1.1.5/O-4_R-1417"],
       "name": "Windalarm",
       "identifier": "GA-7",
       "raw_address": 4102,
+      "address": "2/0/6",
       "dpt_type": null,
+      "communication_object_ids": ["1.1.5/O-4_R-1417"],
       "description": ""
     }
   },

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -19,6 +19,9 @@ class CommunicationObject(TypedDict):
     """Communication object dictionary."""
 
     name: str | None
+    text: str
+    function_text: str
+    description: str
     device_address: str
     dpt_type: dict[str, int]
     group_address_links: list[str]

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -54,7 +54,10 @@ class XMLParser:
                 if com_object.links:
                     com_object_key = f"{device.individual_address}/{com_object.ref_id}"
                     communication_objects[com_object_key] = CommunicationObject(
-                        name=com_object.name or com_object.text,
+                        name=com_object.name,
+                        text=com_object.text or "",
+                        function_text=com_object.function_text or "",
+                        description=com_object.description or "",
                         device_address=device.individual_address,
                         dpt_type=com_object.datapoint_type,  # type: ignore[typeddict-item]
                         flags=Flags(
@@ -188,5 +191,6 @@ class XMLParser:
                 self.knx_proj_contents.root_path, self.devices
             )
         )
+        # update self.devices items with its inherited values from their application programs
         for application_program_file, devices in application_programs.items():
             ApplicationProgramLoader.load(application_program_file, devices)


### PR DESCRIPTION
`"name"` seems to be some internal identifier not shown in ETS, but I guess it's ok to preserve that too.

Module-devices seem to resolve their text templates in their `ComObjectInstanceRef` in the project file - which means we don't have to care about that and they are already translated 😃