### PR TITLE
Support devices with multiple application versions

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -138,9 +138,9 @@
   },
   "devices": {
     "1.1.1": {
-      "name": "Heizungsaktor 8-fach",
-      "product_name": "Heizungsaktor 8-fach",
-      "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "name": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "hardware_name": "Heizungsaktor 8-fach",
+      "description": "",
       "individual_address": "1.1.1",
       "manufacturer_name": "MDT technologies",
       "communication_object_ids": [
@@ -152,9 +152,9 @@
       ]
     },
     "1.1.2": {
-      "name": "Heizungsaktor 8-fach",
-      "product_name": "Heizungsaktor 8-fach",
-      "description": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "name": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "hardware_name": "Heizungsaktor 8-fach",
+      "description": "",
       "individual_address": "1.1.2",
       "manufacturer_name": "MDT technologies",
       "communication_object_ids": ["1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"]

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -134,17 +134,17 @@
   },
   "devices": {
     "1.1.0": {
-      "name": "IP Router Secure",
-      "product_name": "IP Router Secure",
-      "description": "SCN-IP100.03 IP Router with Secure",
+      "name": "SCN-IP100.03 IP Router with Secure",
+      "hardware_name": "IP Router Secure",
+      "description": "",
       "individual_address": "1.1.0",
       "manufacturer_name": "MDT technologies",
       "communication_object_ids": []
     },
     "1.1.5": {
-      "name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
-      "product_name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
-      "description": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
+      "name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
+      "hardware_name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
+      "description": "",
       "individual_address": "1.1.5",
       "manufacturer_name": "ABB",
       "communication_object_ids": [

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -125,24 +125,20 @@ class _TopologyLoader:
         device_element: ElementTree.Element, line: XMLLine
     ) -> DeviceInstance | None:
         """Create device."""
-        identifier: str = device_element.get("Id", "")
         address: str | None = device_element.get("Address")
-
         #  devices like power supplies do usually not have an IA.
         if address is None:
             return None
 
-        name: str = device_element.get("Name", "")
-        last_modified: str = device_element.get("LastModified", "")
         product_ref = device_element.get("ProductRefId", "")
-        hardware_program_ref = device_element.get("Hardware2ProgramRefId", "")
         device: DeviceInstance = DeviceInstance(
-            identifier=identifier,
+            identifier=device_element.get("Id", ""),
             address=address,
-            name=name,
-            last_modified=last_modified,
+            name=device_element.get("Name", ""),
+            description=device_element.get("Description", ""),
+            last_modified=device_element.get("LastModified", ""),
             product_ref=product_ref,
-            hardware_program_ref=hardware_program_ref,
+            hardware_program_ref=device_element.get("Hardware2ProgramRefId", ""),
             line=line,
             manufacturer=product_ref.split("_", 1)[0],
         )

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -134,18 +134,17 @@ class _TopologyLoader:
 
         name: str = device_element.get("Name", "")
         last_modified: str = device_element.get("LastModified", "")
-        _product_ref_parts = device_element.get("ProductRefId", "").split("_")
-        hardware_ref = _product_ref_parts[0] + "_" + _product_ref_parts[1]
+        product_ref = device_element.get("ProductRefId", "")
         hardware_program_ref = device_element.get("Hardware2ProgramRefId", "")
         device: DeviceInstance = DeviceInstance(
             identifier=identifier,
             address=address,
             name=name,
             last_modified=last_modified,
-            hardware_ref=hardware_ref,
+            product_ref=product_ref,
             hardware_program_ref=hardware_program_ref,
             line=line,
-            manufacturer=_product_ref_parts[0],
+            manufacturer=product_ref.split("_", 1)[0],
         )
 
         for sub_node in device_element:

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -14,7 +14,8 @@ from .models import (
     ComObjectInstanceRef,
     ComObjectRef,
     DeviceInstance,
-    Hardware,
+    HardwareToPrograms,
+    Product,
     XMLArea,
     XMLGroupAddress,
     XMLLine,
@@ -40,6 +41,7 @@ __all__ = [
     "XMLGroupAddress",
     "XMLLine",
     "XMLSpace",
-    "Hardware",
+    "HardwareToPrograms",
+    "Product",
     "MEDIUM_TYPES",
 ]

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -29,7 +29,7 @@ class Device(TypedDict):
     """Devices dictionary."""
 
     name: str
-    product_name: str
+    hardware_name: str
     description: str
     manufacturer_name: str
     individual_address: str

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -74,7 +74,7 @@ class DeviceInstance:
         address: str,
         name: str,
         last_modified: str,
-        hardware_ref: str,
+        product_ref: str,
         hardware_program_ref: str,
         line: XMLLine,
         manufacturer: str,
@@ -87,7 +87,7 @@ class DeviceInstance:
         self.address = address
         self.name = name
         self.last_modified = last_modified
-        self.hardware_ref = hardware_ref
+        self.product_ref = product_ref
         self.hardware_program_ref = hardware_program_ref
         self.line = line
         self.manufacturer = manufacturer
@@ -258,12 +258,12 @@ class XMLSpace:
 
 
 @dataclass
-class Hardware:
-    """Model a Hardware instance."""
+class Product:
+    """Model a Product instance."""
 
     identifier: str
-    name: str
-    product_name: str
-    application_program_refs: dict[
-        str, str
-    ]  # {Hardware2ProgramRefID: ApplicationProgramRef}
+    text: str
+    hardware_name: str = ""
+
+
+HardwareToPrograms = dict[str, str]

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -73,6 +73,7 @@ class DeviceInstance:
         identifier: str,
         address: str,
         name: str,
+        description: str,
         last_modified: str,
         product_ref: str,
         hardware_program_ref: str,
@@ -86,6 +87,7 @@ class DeviceInstance:
         self.identifier = identifier
         self.address = address
         self.name = name
+        self.description = description
         self.last_modified = last_modified
         self.product_ref = product_ref
         self.hardware_program_ref = hardware_program_ref

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -71,9 +71,9 @@ class XMLParser:
                     device_com_objects.append(com_object_key)
 
             devices_dict[device.individual_address] = Device(
-                name=device.name or device.product_name,
-                product_name=device.product_name,
-                description=device.hardware_name,
+                name=device.product_name,
+                hardware_name=device.hardware_name,
+                description=device.description,
                 individual_address=device.individual_address,
                 manufacturer_name=device.manufacturer_name,
                 communication_object_ids=device_com_objects,


### PR DESCRIPTION
- Support devices with multiple application versions
these have different `Hardware2ProgramRefId` in a common `Hardware` tag. So the resolution of `Product` and `Hardware2Program` tags is now done with the RefIds from `DeviceInstance` instead of forging a `HardwareRefId` for the `Hardware` tag.
- rename Device product_name to hardware_name 
`name` is product_name
- fix Device descriptions
these have just been a copy of `hardware_name` (which was mixed up with product_name down the stack 🙃)