### PR TITLE
Apply translations

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "language_code": "de-DE",
   "communication_objects": {
     "1.1.1/O-334_R-21": {
       "name": "FuehrungsWert",
@@ -156,7 +157,7 @@
   },
   "devices": {
     "1.1.1": {
-      "name": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
       "description": "",
       "individual_address": "1.1.1",
@@ -170,7 +171,7 @@
       ]
     },
     "1.1.2": {
-      "name": "AKH-0800.03 Heating Actuator 8-fold, 4SU MDRC, 24/230VAC",
+      "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
       "description": "",
       "individual_address": "1.1.2",

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -4,14 +4,16 @@
   "communication_objects": {
     "1.1.1/O-334_R-21": {
       "name": "FuehrungsWert",
-      "text": "Outside temperature / Reference value",
-      "function_text": "Receive measured value",
+      "number": 334,
+      "text": "Außentemperatur / Führungswert",
+      "function_text": "Messwert empfangen",
       "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,
@@ -24,14 +26,16 @@
     },
     "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1": {
       "name": "IstWert",
+      "number": 1,
       "text": "Kanal A: Wohnzimmer",
-      "function_text": "Receive temperature value",
+      "function_text": "Temperaturwert empfangen",
       "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,
@@ -44,14 +48,16 @@
     },
     "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "number": 2,
       "text": "Kanal A: Wohnzimmer",
-      "function_text": "Preset setpoint",
+      "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,
@@ -64,14 +70,16 @@
     },
     "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1": {
       "name": "IstWert",
+      "number": 1,
       "text": "Kanal B: Küche",
-      "function_text": "Receive temperature value",
+      "function_text": "Temperaturwert empfangen",
       "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,
@@ -84,14 +92,16 @@
     },
     "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "number": 2,
       "text": "Kanal B: Küche",
-      "function_text": "Preset setpoint",
+      "function_text": "Sollwert vorgeben",
       "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,
@@ -104,14 +114,16 @@
     },
     "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3": {
       "name": "SollWert",
+      "number": 2,
       "text": "Kanal A: Bad",
-      "function_text": "Preset setpoint",
+      "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.2",
       "dpt_type": {
         "main": 9,
         "sub": 1
       },
+      "object_size": "2 Bytes",
       "flags": {
         "read": false,
         "write": true,

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -1,5 +1,6 @@
 {
   "version": "2.1.0",
+  "language_code": null,
   "communication_objects": {
     "1.1.5/O-40_R-1433": {
       "name": "Ausgang B",

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -4,11 +4,13 @@
   "communication_objects": {
     "1.1.5/O-40_R-1433": {
       "name": "Ausgang B",
+      "number": 40,
       "text": "Output B",
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -21,11 +23,13 @@
     },
     "1.1.5/O-41_R-1434": {
       "name": "Ausgang B",
+      "number": 41,
       "text": "Output B",
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -38,11 +42,16 @@
     },
     "1.1.5/O-70_R-1505": {
       "name": "Ausgang C",
+      "number": 70,
       "text": "Output C",
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt_type": { "main": 1, "sub": 8 },
+      "dpt_type": {
+        "main": 1,
+        "sub": 8
+      },
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -55,11 +64,16 @@
     },
     "1.1.5/O-71_R-1506": {
       "name": "Ausgang C",
+      "number": 71,
       "text": "Output C",
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt_type": { "main": 1, "sub": 8 },
+      "dpt_type": {
+        "main": 1,
+        "sub": 8
+      },
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -72,11 +86,13 @@
     },
     "1.1.5/O-100_R-1577": {
       "name": "Ausgang D",
+      "number": 100,
       "text": "Output D",
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
       "dpt_type": {},
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -89,11 +105,16 @@
     },
     "1.1.5/O-101_R-1578": {
       "name": "Ausgang D",
+      "number": 101,
       "text": "Output D",
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt_type": { "main": 1, "sub": 8 },
+      "dpt_type": {
+        "main": 1,
+        "sub": 8
+      },
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -106,11 +127,16 @@
     },
     "1.1.5/O-4_R-1417": {
       "name": "Ausgang A-X",
+      "number": 4,
       "text": "Output A-X",
       "function_text": "Wind alarm no. 1",
       "description": "",
       "device_address": "1.1.5",
-      "dpt_type": { "main": 1, "sub": 1 },
+      "dpt_type": {
+        "main": 1,
+        "sub": 1
+      },
+      "object_size": "1 Bit",
       "flags": {
         "read": false,
         "write": true,
@@ -246,6 +272,10 @@
     }
   },
   "locations": {
-    "Test (1)": { "type": "Building", "devices": [], "spaces": {} }
+    "Test (1)": {
+      "type": "Building",
+      "devices": [],
+      "spaces": {}
+    }
   }
 }

--- a/test/test_knxproj.py
+++ b/test/test_knxproj.py
@@ -13,6 +13,9 @@ def test_parse_project_ets5():
 
 def test_parse_project_modules():
     """Test parsing of ETS5 project including 2 identical devices with module definitions."""
-    knxproj = XKNXProj(RESOURCES_PATH / "module-definition-test.knxproj")
+    knxproj = XKNXProj(
+        RESOURCES_PATH / "module-definition-test.knxproj",
+        language_code="de-DE",
+    )
     project = knxproj.parse()
     assert_stub(project, "module-definition-test.json")

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -35,7 +35,8 @@ class ApplicationProgramLoader:
         com_objects: dict[str, ComObject] = {}  # {Id: ComObject}
 
         in_language = False
-        in_translation_ref: dict[str, str] | None = None
+        in_translation_ref: str | None = None  # TranslationElement RefId
+        # translation_map: {TranslationElement RefId: {AttributeName: Text}}
         translation_map: dict[str, dict[str, str]] = {}
 
         with application_program_path.open(mode="rb") as application_xml:
@@ -99,13 +100,15 @@ class ApplicationProgramLoader:
                         break
                     in_language = elem.get("Identifier") == language_code
                 elif in_language and elem.tag.endswith("TranslationElement"):
-                    in_translation_ref = translation_map[elem.get("RefId")] = {}
+                    in_translation_ref = elem.get("RefId")
                 elif (
                     in_language
                     and in_translation_ref is not None
                     and elem.tag.endswith("Translation")
                 ):
-                    in_translation_ref[elem.get("AttributeName")] = elem.get("Text")
+                    translation_map.setdefault(in_translation_ref, {})[
+                        elem.get("AttributeName")
+                    ] = elem.get("Text")
                 elem.clear()
 
             if translation_map:

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -91,10 +91,6 @@ class ApplicationProgramLoader:
         used_com_object_ids = {
             com_object_ref.ref_id for com_object_ref in com_object_refs.values()
         }
-        # remove unused com_objects
-        for unused_key in com_objects.keys() ^ used_com_object_ids:
-            del com_objects[unused_key]
-
         used_translation_ids = used_com_object_ids | used_com_object_ref_ids
         in_language = False
         in_translation_ref: str | None = None  # TranslationElement RefId
@@ -103,7 +99,7 @@ class ApplicationProgramLoader:
         for _, elem in tree_iterator:
             if elem.tag.endswith("Language"):
                 if in_language:
-                    # Already found the language we are looking for
+                    # Already found the language we are looking for.
                     # We don't need anything after that tag (there isn't much anyway)
                     elem.clear()
                     break
@@ -121,11 +117,8 @@ class ApplicationProgramLoader:
                 ] = elem.get("Text")
             elem.clear()
 
-        if translation_map:
-            ApplicationProgramLoader.apply_translations(
-                com_object_refs, translation_map
-            )
-            ApplicationProgramLoader.apply_translations(com_objects, translation_map)
+        ApplicationProgramLoader.apply_translations(com_object_refs, translation_map)
+        ApplicationProgramLoader.apply_translations(com_objects, translation_map)
 
     @staticmethod
     def parse_com_object(
@@ -179,12 +172,13 @@ class ApplicationProgramLoader:
         translation_map: dict[str, dict[str, str]],
     ) -> None:
         """Apply translations to ComObjects and ComObjectRefs."""
-        for com_object in com_objects.values():
-            if translation := translation_map.get(com_object.identifier):
-                if _text := translation.get("Text"):
-                    com_object.text = _text
-                if _function_text := translation.get("FunctionText"):
-                    com_object.function_text = _function_text
+        for identifier in com_objects.keys() & translation_map.keys():
+            translation = translation_map[identifier]
+            com_object = com_objects[identifier]
+            if _text := translation.get("Text"):
+                com_object.text = _text
+            if _function_text := translation.get("FunctionText"):
+                com_object.function_text = _function_text
 
     @staticmethod
     def get_application_program_files_for_devices(

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -1,7 +1,9 @@
 """Application Program Loader."""
 from __future__ import annotations
 
+from collections.abc import Iterator
 import logging
+from typing import Any
 from xml.etree import ElementTree
 from zipfile import Path
 
@@ -34,89 +36,36 @@ class ApplicationProgramLoader:
         com_object_refs: dict[str, ComObjectRef] = {}  # {Id: ComObjectRef}
         com_objects: dict[str, ComObject] = {}  # {Id: ComObject}
 
-        in_language = False
-        in_translation_ref: str | None = None  # TranslationElement RefId
-        # translation_map: {TranslationElement RefId: {AttributeName: Text}}
-        translation_map: dict[str, dict[str, str]] = {}
-
         with application_program_path.open(mode="rb") as application_xml:
-            for _, elem in ElementTree.iterparse(application_xml, events=("start",)):
+            tree_iterator = ElementTree.iterparse(application_xml, events=("start",))
+            for _, elem in tree_iterator:
                 if elem.tag.endswith("ComObject"):
                     # we take all since we don't know which are referenced to yet
                     identifier = elem.attrib.get("Id")
-                    com_objects[identifier] = ComObject(
-                        identifier=identifier,
-                        name=elem.get("Name"),
-                        text=elem.get("Text"),
-                        number=int(elem.get("Number", 0)),
-                        function_text=elem.get("FunctionText"),
-                        object_size=elem.get("ObjectSize"),
-                        read_flag=parse_xml_flag(elem.get("ReadFlag"), False),
-                        write_flag=parse_xml_flag(elem.get("WriteFlag"), False),
-                        communication_flag=parse_xml_flag(
-                            elem.get("CommunicationFlag"), False
-                        ),
-                        transmit_flag=parse_xml_flag(elem.get("TransmitFlag"), False),
-                        update_flag=parse_xml_flag(elem.get("UpdateFlag"), False),
-                        read_on_init_flag=parse_xml_flag(
-                            elem.get("ReadOnInitFlag"), False
-                        ),
-                        datapoint_type=parse_dpt_types(
-                            elem.get("DatapointType", "").split(" ")
-                        ),
+                    com_objects[identifier] = ApplicationProgramLoader.parse_com_object(
+                        elem, identifier
                     )
                 elif elem.tag.endswith("ComObjectRef"):
                     identifier = elem.attrib.get("Id")
                     if identifier not in used_com_object_ref_ids:
                         elem.clear()
                         continue
-                    _dpt_type = elem.get("DatapointType")
-                    datapoint_type = (
-                        parse_dpt_types(_dpt_type.split(" ")) if _dpt_type else None
-                    )
-                    com_object_refs[identifier] = ComObjectRef(
-                        identifier=identifier,
-                        ref_id=elem.get("RefId"),
-                        name=elem.get("Name"),
-                        text=elem.get("Text"),
-                        function_text=elem.get("FunctionText"),
-                        object_size=elem.get("ObjectSize"),
-                        read_flag=parse_xml_flag(elem.get("ReadFlag")),
-                        write_flag=parse_xml_flag(elem.get("WriteFlag")),
-                        communication_flag=parse_xml_flag(
-                            elem.get("CommunicationFlag")
-                        ),
-                        transmit_flag=parse_xml_flag(elem.get("TransmitFlag")),
-                        update_flag=parse_xml_flag(elem.get("UpdateFlag")),
-                        read_on_init_flag=parse_xml_flag(elem.get("ReadOnInitFlag")),
-                        datapoint_type=datapoint_type,
-                    )
-                # Translations
-                elif elem.tag.endswith("Language"):
-                    if in_language or language_code is None:
-                        # Already found the language we are looking for or we are not translating
-                        # We don't need anything after that tag (there isn't much anyway)
-                        elem.clear()
-                        break
-                    in_language = elem.get("Identifier") == language_code
-                elif in_language and elem.tag.endswith("TranslationElement"):
-                    in_translation_ref = elem.get("RefId")
-                elif (
-                    in_language
-                    and in_translation_ref is not None
-                    and elem.tag.endswith("Translation")
-                ):
-                    translation_map.setdefault(in_translation_ref, {})[
-                        elem.get("AttributeName")
-                    ] = elem.get("Text")
+                    com_object_refs[
+                        identifier
+                    ] = ApplicationProgramLoader.parse_com_object_ref(elem, identifier)
+                elif elem.tag.endswith("Languages"):
+                    elem.clear()
+                    # hold iterator for optional translation parsing
+                    break
                 elem.clear()
 
-            if translation_map:
-                ApplicationProgramLoader.apply_translations(
-                    com_object_refs, translation_map
-                )
-                ApplicationProgramLoader.apply_translations(
-                    com_objects, translation_map
+            if language_code is not None:
+                ApplicationProgramLoader.parse_translations(
+                    tree_iterator=tree_iterator,
+                    com_objects=com_objects,
+                    com_object_refs=com_object_refs,
+                    used_com_object_ref_ids=used_com_object_ref_ids,
+                    language_code=language_code,
                 )
 
             for com_instance in com_object_instance_refs:
@@ -129,6 +78,100 @@ class ApplicationProgramLoader:
                 _com_object_ref = com_object_refs[com_instance.com_object_ref_id]
                 com_instance.merge_from_application(_com_object_ref)
                 com_instance.merge_from_application(com_objects[_com_object_ref.ref_id])
+
+    @staticmethod
+    def parse_translations(
+        tree_iterator: Iterator[tuple[str, Any]],
+        com_objects: dict[str, ComObject],
+        com_object_refs: dict[str, ComObjectRef],
+        used_com_object_ref_ids: set[str],
+        language_code: str,
+    ) -> None:
+        """Parse translations. Replace translated text in com_objects and com_object_refs."""
+        used_com_object_ids = {
+            com_object_ref.ref_id for com_object_ref in com_object_refs.values()
+        }
+        # remove unused com_objects
+        for unused_key in com_objects.keys() ^ used_com_object_ids:
+            del com_objects[unused_key]
+
+        used_translation_ids = used_com_object_ids | used_com_object_ref_ids
+        in_language = False
+        in_translation_ref: str | None = None  # TranslationElement RefId
+        # translation_map: {TranslationElement RefId: {AttributeName: Text}}
+        translation_map: dict[str, dict[str, str]] = {}
+        for _, elem in tree_iterator:
+            if elem.tag.endswith("Language"):
+                if in_language:
+                    # Already found the language we are looking for
+                    # We don't need anything after that tag (there isn't much anyway)
+                    elem.clear()
+                    break
+                in_language = elem.get("Identifier") == language_code
+            elif in_language and elem.tag.endswith("TranslationElement"):
+                ref_id = elem.get("RefId")
+                in_translation_ref = ref_id if ref_id in used_translation_ids else None
+            elif (
+                in_language
+                and in_translation_ref is not None
+                and elem.tag.endswith("Translation")
+            ):
+                translation_map.setdefault(in_translation_ref, {})[
+                    elem.get("AttributeName")
+                ] = elem.get("Text")
+            elem.clear()
+
+        if translation_map:
+            ApplicationProgramLoader.apply_translations(
+                com_object_refs, translation_map
+            )
+            ApplicationProgramLoader.apply_translations(com_objects, translation_map)
+
+    @staticmethod
+    def parse_com_object(
+        elem: ElementTree.Element,
+        identifier: str,
+    ) -> ComObject:
+        """Parse ComObject tag."""
+        return ComObject(
+            identifier=identifier,
+            name=elem.get("Name"),  # type: ignore[arg-type]
+            text=elem.get("Text"),  # type: ignore[arg-type]
+            number=int(elem.get("Number", 0)),
+            function_text=elem.get("FunctionText"),  # type: ignore[arg-type]
+            object_size=elem.get("ObjectSize"),  # type: ignore[arg-type]
+            read_flag=parse_xml_flag(elem.get("ReadFlag"), False),
+            write_flag=parse_xml_flag(elem.get("WriteFlag"), False),
+            communication_flag=parse_xml_flag(elem.get("CommunicationFlag"), False),
+            transmit_flag=parse_xml_flag(elem.get("TransmitFlag"), False),
+            update_flag=parse_xml_flag(elem.get("UpdateFlag"), False),
+            read_on_init_flag=parse_xml_flag(elem.get("ReadOnInitFlag"), False),
+            datapoint_type=parse_dpt_types(elem.get("DatapointType", "").split(" ")),
+        )
+
+    @staticmethod
+    def parse_com_object_ref(
+        elem: ElementTree.Element,
+        identifier: str,
+    ) -> ComObjectRef:
+        """Parse ComObjectRef tag."""
+        _dpt_type = elem.get("DatapointType")
+        datapoint_type = parse_dpt_types(_dpt_type.split(" ")) if _dpt_type else None
+        return ComObjectRef(
+            identifier=identifier,
+            ref_id=elem.get("RefId"),  # type: ignore[arg-type]
+            name=elem.get("Name"),
+            text=elem.get("Text"),
+            function_text=elem.get("FunctionText"),
+            object_size=elem.get("ObjectSize"),
+            read_flag=parse_xml_flag(elem.get("ReadFlag")),
+            write_flag=parse_xml_flag(elem.get("WriteFlag")),
+            communication_flag=parse_xml_flag(elem.get("CommunicationFlag")),
+            transmit_flag=parse_xml_flag(elem.get("TransmitFlag")),
+            update_flag=parse_xml_flag(elem.get("UpdateFlag")),
+            read_on_init_flag=parse_xml_flag(elem.get("ReadOnInitFlag")),
+            datapoint_type=datapoint_type,
+        )
 
     @staticmethod
     def apply_translations(

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -80,6 +80,7 @@ class KNXProject(TypedDict):
     """KNXProject typed dictionary."""
 
     version: str
+    language_code: str | None
     communication_objects: dict[str, CommunicationObject]
     devices: dict[str, Device]
     topology: dict[str, Area]

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -18,12 +18,14 @@ class Flags(TypedDict):
 class CommunicationObject(TypedDict):
     """Communication object dictionary."""
 
-    name: str | None
+    name: str
+    number: int
     text: str
     function_text: str
     description: str
     device_address: str
     dpt_type: dict[str, int]
+    object_size: str
     group_address_links: list[str]
     flags: Flags
 

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -178,7 +178,7 @@ class ComObjectInstanceRef:
             self.number = com_object.number
 
 
-@dataclass(frozen=True)
+@dataclass
 class ComObject:
     """Class that represents a ComObject instance."""
 
@@ -214,7 +214,7 @@ class ComObject:
     datapoint_type: dict[str, int] | None  # "DataPointType" - knx:IDREFS - optional
 
 
-@dataclass(frozen=True)
+@dataclass
 class ComObjectRef:
     """Class that represents a ComObjectRef instance."""
 

--- a/xknxproject/xknxproj.py
+++ b/xknxproject/xknxproj.py
@@ -16,14 +16,16 @@ class XKNXProj:
         self,
         archive_name: str | Path,
         archive_password: str | None = None,
+        language_code: str | None = None,
     ):
         """Initialize a KNXProjParser."""
         self.archive_path = Path(archive_name)
         self.password = archive_password
+        self.language_code = language_code
 
         self.version = __version__
 
     def parse(self) -> KNXProject:
         """Parse the KNX project."""
         with extract(self.archive_path, self.password) as knx_project_content:
-            return XMLParser(knx_project_content).parse()
+            return XMLParser(knx_project_content).parse(self.language_code)

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -43,9 +43,9 @@ class XMLParser:
         self.areas: list[XMLArea] = []
         self.devices: list[DeviceInstance] = []
 
-    def parse(self) -> KNXProject:
+    def parse(self, language_code: str | None = None) -> KNXProject:
         """Parse ETS files."""
-        self.load()
+        self.load(language_code=language_code)
 
         communication_objects: dict[str, CommunicationObject] = {}
         devices_dict: dict[str, Device] = {}
@@ -122,6 +122,7 @@ class XMLParser:
 
         return KNXProject(
             version=__version__,
+            language_code=language_code,
             communication_objects=communication_objects,
             topology=topology_dict,
             devices=devices_dict,
@@ -137,7 +138,7 @@ class XMLParser:
 
         return Space(type=space.type.value, devices=space.devices, spaces=subspaces)
 
-    def load(self) -> None:
+    def load(self, language_code: str | None) -> None:
         """Load XML files."""
         (
             self.group_addresses,
@@ -153,7 +154,7 @@ class XMLParser:
         products_dict: dict[str, Product] = {}
         hardware_application_map: HardwareToPrograms = {}
         for _products, _hardware_programs in [
-            HardwareLoader.load(hardware_file)
+            HardwareLoader.load(hardware_file, language_code=language_code)
             for hardware_file in HardwareLoader.get_hardware_files(
                 self.knx_proj_contents
             )


### PR DESCRIPTION
Translate
- hardware product names
- communication object information

Add number and object_size to communication objects.

Translation is based on given a language_code. If `None`, the default language will be used.

```py
knxproj: XKNXProj = XKNXProj(
    archive_name="test.knxproj",
    archive_password="test",
    language_code="de-DE",
)
```
This increases parsing time (on my personal project) by ~~25~~ ~22% and peak memory usage by ~5%.
```
                      Py 3.10         Py 3.11
before                1.31 sec        1.22 sec
    scalene           20.199 MB       20.189 MB
    fil               13.3 MiB        14.5 MiB

language_code=None    1.30 sec        1.22 sec
    scalene           20.311 MB       20.189 MB
    fil               13.3 MiB        14.5 MiB

language_code="de-DE" 1.58 sec        1.49 sec
    scalene           20.313 MB       20.189 MB
    fil               13.3 MiB        14.5 MiB
```