### PR TITLE
Add project_uid for group addresses and devices

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -172,8 +172,9 @@
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
       "description": "",
-      "individual_address": "1.1.1",
       "manufacturer_name": "MDT technologies",
+      "individual_address": "1.1.1",
+      "project_uid": 12,
       "communication_object_ids": [
         "1.1.1/O-334_R-21",
         "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1",
@@ -186,8 +187,9 @@
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
       "description": "",
-      "individual_address": "1.1.2",
       "manufacturer_name": "MDT technologies",
+      "individual_address": "1.1.2",
+      "project_uid": 13,
       "communication_object_ids": ["1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"]
     }
   },
@@ -197,6 +199,7 @@
       "identifier": "GA-1",
       "raw_address": 1,
       "address": "0/0/1",
+      "project_uid": 9,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -209,6 +212,7 @@
       "identifier": "GA-2",
       "raw_address": 2,
       "address": "0/0/2",
+      "project_uid": 10,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -221,6 +225,7 @@
       "identifier": "GA-3",
       "raw_address": 3,
       "address": "0/0/3",
+      "project_uid": 11,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -233,6 +238,7 @@
       "identifier": "GA-4",
       "raw_address": 258,
       "address": "0/1/2",
+      "project_uid": 16,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -245,6 +251,7 @@
       "identifier": "GA-7",
       "raw_address": 257,
       "address": "0/1/1",
+      "project_uid": 20,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -257,6 +264,7 @@
       "identifier": "GA-5",
       "raw_address": 514,
       "address": "0/2/2",
+      "project_uid": 17,
       "dpt_type": {
         "main": 9,
         "sub": 1
@@ -269,6 +277,7 @@
       "identifier": "GA-6",
       "raw_address": 1794,
       "address": "0/7/2",
+      "project_uid": 19,
       "dpt_type": {
         "main": 9,
         "sub": 1

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -185,16 +185,18 @@
       "name": "SCN-IP100.03 IP Router with Secure",
       "hardware_name": "IP Router Secure",
       "description": "",
-      "individual_address": "1.1.0",
       "manufacturer_name": "MDT technologies",
+      "individual_address": "1.1.0",
+      "project_uid": 25,
       "communication_object_ids": []
     },
     "1.1.5": {
       "name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "hardware_name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
       "description": "",
-      "individual_address": "1.1.5",
       "manufacturer_name": "ABB",
+      "individual_address": "1.1.5",
+      "project_uid": 31,
       "communication_object_ids": [
         "1.1.5/O-40_R-1433",
         "1.1.5/O-41_R-1434",
@@ -212,6 +214,7 @@
       "identifier": "GA-1",
       "raw_address": 2048,
       "address": "1/0/0",
+      "project_uid": 34,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-101_R-1578"],
       "description": ""
@@ -221,6 +224,7 @@
       "identifier": "GA-2",
       "raw_address": 2049,
       "address": "1/0/1",
+      "project_uid": 35,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-100_R-1577"],
       "description": ""
@@ -230,6 +234,7 @@
       "identifier": "GA-3",
       "raw_address": 2050,
       "address": "1/0/2",
+      "project_uid": 36,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-71_R-1506"],
       "description": ""
@@ -239,6 +244,7 @@
       "identifier": "GA-4",
       "raw_address": 2051,
       "address": "1/0/3",
+      "project_uid": 37,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-70_R-1505"],
       "description": ""
@@ -248,6 +254,7 @@
       "identifier": "GA-5",
       "raw_address": 2052,
       "address": "1/0/4",
+      "project_uid": 38,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-41_R-1434"],
       "description": ""
@@ -257,6 +264,7 @@
       "identifier": "GA-6",
       "raw_address": 2053,
       "address": "1/0/5",
+      "project_uid": 39,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-40_R-1433"],
       "description": ""
@@ -266,6 +274,7 @@
       "identifier": "GA-7",
       "raw_address": 4102,
       "address": "2/0/6",
+      "project_uid": 42,
       "dpt_type": null,
       "communication_object_ids": ["1.1.5/O-4_R-1417"],
       "description": ""

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -73,6 +73,7 @@ class _GroupAddressLoader:
             name=group_address_element.get("Name", ""),
             identifier=group_address_element.get("Id", ""),
             address=group_address_element.get("Address", ""),
+            project_uid=int(group_address_element.get("Puid")),  # type: ignore[arg-type]
             dpt_type=group_address_element.get("DatapointType"),
             description=group_address_element.get("Description", ""),
         )
@@ -137,6 +138,7 @@ class _TopologyLoader:
         device: DeviceInstance = DeviceInstance(
             identifier=device_element.get("Id", ""),
             address=address,
+            project_uid=int(device_element.get("Puid")),  # type: ignore[arg-type]
             name=device_element.get("Name", ""),
             description=device_element.get("Description", ""),
             last_modified=device_element.get("LastModified", ""),

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -38,6 +38,7 @@ class Device(TypedDict):
     description: str
     manufacturer_name: str
     individual_address: str
+    project_uid: int
     communication_object_ids: list[str]
 
 
@@ -65,6 +66,7 @@ class GroupAddress(TypedDict):
     identifier: str
     raw_address: int
     address: str
+    project_uid: int
     dpt_type: dict[str, int] | None
     communication_object_ids: list[str]
     description: str

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -16,6 +16,7 @@ class XMLGroupAddress:
         name: str,
         identifier: str,
         address: str,
+        project_uid: int,
         description: str,
         dpt_type: str | None,
     ):
@@ -23,6 +24,7 @@ class XMLGroupAddress:
         self.name = name
         self.identifier = identifier.split("_")[1]
         self.raw_address = int(address)
+        self.project_uid = project_uid
         self.description = description
         self.dpt_type = (
             None if dpt_type is None else parse_dpt_types(dpt_type.split(" "))
@@ -72,6 +74,7 @@ class DeviceInstance:
         *,
         identifier: str,
         address: str,
+        project_uid: int,
         name: str,
         description: str,
         last_modified: str,
@@ -88,6 +91,7 @@ class DeviceInstance:
         self.address = address
         self.name = name
         self.description = description
+        self.project_uid = project_uid
         self.last_modified = last_modified
         self.product_ref = product_ref
         self.hardware_program_ref = hardware_program_ref

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -79,8 +79,9 @@ class XMLParser:
                 name=device.product_name,
                 hardware_name=device.hardware_name,
                 description=device.description,
-                individual_address=device.individual_address,
                 manufacturer_name=device.manufacturer_name,
+                individual_address=device.individual_address,
+                project_uid=device.project_uid,
                 communication_object_ids=device_com_objects,
             )
 
@@ -113,6 +114,7 @@ class XMLParser:
                 identifier=group_address.identifier,
                 raw_address=group_address.raw_address,
                 address=group_address.address,
+                project_uid=group_address.project_uid,
                 dpt_type=group_address.dpt_type,
                 communication_object_ids=_com_object_ids,
                 description=group_address.description,


### PR DESCRIPTION
These are integers that are unique project wide.
They could become handy for migrations to new versions or updated project data at some point.