### PR TITLE
Parse AdditionalAddresses

### DIFF
--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -151,8 +151,11 @@ class _TopologyLoader:
         for sub_node in device_element:
             if sub_node.tag.endswith("AdditionalAddresses"):
                 for address_node in sub_node:
-                    if _address := address_node.get("Address"):
-                        device.additional_addresses.append(_address)
+                    device.add_additional_address(
+                        device_address=address_node.get("Address"),  # type: ignore[arg-type]
+                        description=address_node.get("Description", ""),
+                        name=address_node.get("Name"),
+                    )
             if sub_node.tag.endswith("ComObjectInstanceRefs"):
                 for com_object in sub_node:
                     if instance := _TopologyLoader._create_com_object_instance(

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -82,7 +82,6 @@ class DeviceInstance:
         hardware_program_ref: str,
         line: XMLLine,
         manufacturer: str,
-        additional_addresses: list[str] | None = None,
         com_object_instance_refs: list[ComObjectInstanceRef] | None = None,
         com_objects: list[ComObject] | None = None,
     ):
@@ -97,7 +96,7 @@ class DeviceInstance:
         self.hardware_program_ref = hardware_program_ref
         self.line = line
         self.manufacturer = manufacturer
-        self.additional_addresses = additional_addresses or []
+        self.additional_addresses: list[AdditionalAddress] = []
         self.com_object_instance_refs = com_object_instance_refs or []
         self.com_objects = com_objects or []
         self.application_program_ref: str | None = None
@@ -109,15 +108,32 @@ class DeviceInstance:
         self.hardware_name: str = ""
         self.manufacturer_name: str = ""
 
-    def add_additional_address(self, address: str) -> None:
+    def add_additional_address(
+        self, device_address: str, description: str, name: str | None
+    ) -> None:
         """Add an additional individual address."""
         self.additional_addresses.append(
-            f"{self.line.area.address}/{self.line.address}/{address}"
+            AdditionalAddress(
+                address=f"{self.line.area.address}.{self.line.address}.{device_address}",
+                description=description,
+                name=name,
+            )
         )
 
     def application_program_xml(self) -> str:
         """Obtain the file name to the application program XML."""
         return f"{self.manufacturer}/{self.application_program_ref}.xml"
+
+
+@dataclass
+class AdditionalAddress:
+    """Class that represents an additional address of IP interfaces."""
+
+    address: str
+    description: str  # default: ""
+    # TODO: IP Secure interfaces use `BusInterface` to transport name and
+    # leave this an empty string. I don't know how `AddressIndex` relates.
+    name: str | None
 
 
 @dataclass


### PR DESCRIPTION
don't use them in the result yet.

IP Secure interfaces use `BusInterface` to transport name and leave the name attribute of `AdditionalAddress` tags an empty string. I don't know how `BusInterface[@AddressIndex]` relates to an `AdditionalAddress` tag.

Also there are no communication objects for AdditionalAddress so maybe they should have their own root key in the final result. A BusInterface may have `Connectors` containing their Associations as `GroupAddressRefId` - which doesn't really add to our current reference schema (GroupAddress -> CommunicationObject and Device -> CommunicationObject) 😬