### PR TITLE
Parse project infos to `info` key

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -1,6 +1,16 @@
 {
-  "version": "2.1.0",
-  "language_code": "de-DE",
+  "info": {
+    "project_id": "P-080F",
+    "name": "ModuleDefinitionTest",
+    "last_modified": "2023-04-11T21:06:02.8735147Z",
+    "group_address_style": "ThreeLevel",
+    "guid": "26520acd-6231-4fe4-a409-4d1610e7a251",
+    "created_by": "ETS5",
+    "schema_version": "20",
+    "tool_version": "5.7.1428.39779",
+    "xknxproject_version": "2.1.0",
+    "language_code": "de-DE"
+  },
   "communication_objects": {
     "1.1.1/O-334_R-21": {
       "name": "FuehrungsWert",

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -1,6 +1,16 @@
 {
-  "version": "2.1.0",
-  "language_code": null,
+  "info": {
+    "project_id": "P-0242",
+    "name": "Test (1)",
+    "last_modified": "2022-04-21T17:18:43.3042783Z",
+    "group_address_style": "ThreeLevel",
+    "guid": "7aceb083-274e-4568-806f-b8f9df992873",
+    "created_by": "ETS5",
+    "schema_version": "20",
+    "tool_version": "5.7.1428.39779",
+    "xknxproject_version": "2.1.0",
+    "language_code": null
+  },
   "communication_objects": {
     "1.1.5/O-40_R-1433": {
       "name": "Ausgang B",

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -7,6 +7,7 @@ from .knxproject import (
     GroupAddress,
     KNXProject,
     Line,
+    ProjectInfo,
     Space,
 )
 from .models import (
@@ -19,29 +20,32 @@ from .models import (
     XMLArea,
     XMLGroupAddress,
     XMLLine,
+    XMLProjectInformation,
     XMLSpace,
 )
 from .static import MEDIUM_TYPES, SpaceType
 
 __all__ = [
     "Area",
-    "Line",
     "CommunicationObject",
-    "GroupAddress",
     "Device",
     "Flags",
+    "GroupAddress",
     "KNXProject",
-    "XMLArea",
+    "Line",
+    "ProjectInfo",
+    "Space",
     "ComObject",
     "ComObjectInstanceRef",
     "ComObjectRef",
-    "SpaceType",
-    "Space",
     "DeviceInstance",
+    "HardwareToPrograms",
+    "Product",
+    "XMLArea",
     "XMLGroupAddress",
     "XMLLine",
     "XMLSpace",
-    "HardwareToPrograms",
-    "Product",
+    "XMLProjectInformation",
     "MEDIUM_TYPES",
+    "SpaceType",
 ]

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -87,11 +87,25 @@ class Space(TypedDict):
     spaces: dict[str, Space]
 
 
+class ProjectInfo(TypedDict):
+    """Information about the project."""
+
+    project_id: str
+    name: str
+    last_modified: str | None
+    group_address_style: str
+    guid: str
+    created_by: str
+    schema_version: str
+    tool_version: str
+    xknxproject_version: str
+    language_code: str | None
+
+
 class KNXProject(TypedDict):
     """KNXProject typed dictionary."""
 
-    version: str
-    language_code: str | None
+    info: ProjectInfo
     communication_objects: dict[str, CommunicationObject]
     devices: dict[str, Device]
     topology: dict[str, Area]

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -279,3 +279,18 @@ class Product:
 
 
 HardwareToPrograms = dict[str, str]
+
+
+@dataclass
+class XMLProjectInformation:
+    """Model a ProjectInformation instance."""
+
+    # ProjectInformation tag is not required in XSD, thus everything is optional
+    project_id: str = ""
+    name: str = ""
+    last_modified: str | None = None
+    group_address_style: str = ""
+    guid: str = ""
+    created_by: str = ""
+    schema_version: str = ""
+    tool_version: str = ""

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -22,9 +22,11 @@ from xknxproject.models import (
     KNXProject,
     Line,
     Product,
+    ProjectInfo,
     Space,
     XMLArea,
     XMLGroupAddress,
+    XMLProjectInformation,
     XMLSpace,
 )
 from xknxproject.zip.extractor import KNXProjContents
@@ -43,6 +45,8 @@ class XMLParser:
         self.areas: list[XMLArea] = []
         self.devices: list[DeviceInstance] = []
         self.language_code: str | None = None
+
+        self.project_info: XMLProjectInformation
 
     def parse(self, language: str | None = None) -> KNXProject:
         """Parse ETS files."""
@@ -129,9 +133,21 @@ class XMLParser:
         for space in self.spaces:
             space_dict[space.name] = self.recursive_convert_spaces(space)
 
-        return KNXProject(
-            version=__version__,
+        info = ProjectInfo(
+            project_id=self.project_info.project_id,
+            name=self.project_info.name,
+            last_modified=self.project_info.last_modified,
+            group_address_style=self.project_info.group_address_style,
+            guid=self.project_info.guid,
+            created_by=self.project_info.created_by,
+            schema_version=self.project_info.schema_version,
+            tool_version=self.project_info.tool_version,
+            xknxproject_version=__version__,
             language_code=self.language_code,
+        )
+
+        return KNXProject(
+            info=info,
             communication_objects=communication_objects,
             topology=topology_dict,
             devices=devices_dict,
@@ -173,6 +189,7 @@ class XMLParser:
             self.areas,
             self.devices,
             self.spaces,
+            self.project_info,
         ) = ProjectLoader.load(
             knx_proj_contents=self.knx_proj_contents,
             space_usage_names=space_usage_names,


### PR DESCRIPTION
`version` key is moved to `xknxproject_version` in `info`. 
`language_code` is also moved into `info`.
```json
{
  "info": {
    "project_id": "P-080F",
    "name": "ModuleDefinitionTest",
    "last_modified": "2023-04-11T21:06:02.8735147Z",
    "group_address_style": "ThreeLevel",
    "guid": "26520acd-6231-4fe4-a409-4d1610e7a251",
    "created_by": "ETS5",
    "schema_version": "20",
    "tool_version": "5.7.1428.39779",
    "xknxproject_version": "2.1.0",
    "language_code": "de-DE"
  },
```