### PR TITLE
Simplify parameters names of XKNXProj

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ from xknxproject import XKNXProj
 
 
 knxproj: XKNXProj = XKNXProj(
-    archive_name="path/to/your/file.knxproj",
-    archive_password="password",  # optional
+    path="path/to/your/file.knxproj",
+    password="password",  # optional
     language="de-DE",  # optional
 )
 project: KNXProject = knxproj.parse()

--- a/xknxproject/xknxproj.py
+++ b/xknxproject/xknxproj.py
@@ -14,18 +14,18 @@ class XKNXProj:
 
     def __init__(
         self,
-        archive_name: str | Path,
-        archive_password: str | None = None,
+        path: str | Path,
+        password: str | None = None,
         language: str | None = None,
     ):
         """Initialize a KNXProjParser."""
-        self.archive_path = Path(archive_name)
-        self.password = archive_password
+        self.path = Path(path)
+        self.password = password
         self.language = language
 
         self.version = __version__
 
     def parse(self) -> KNXProject:
         """Parse the KNX project."""
-        with extract(self.archive_path, self.password) as knx_project_content:
+        with extract(self.path, self.password) as knx_project_content:
             return XMLParser(knx_project_content).parse(self.language)


### PR DESCRIPTION
use `path` instead of `archive_name` as we expect the project file path here.

"Archive" may be confusing if one doesn't know internals of `.knxproj` files - especially since there are also `.knxprojarchive` files created by ETS which we don't support. 