### PR TITLE
Parse a list of all DPTs of a communication object instead of just the last DPT

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -8,7 +8,7 @@
     "created_by": "ETS5",
     "schema_version": "20",
     "tool_version": "5.7.1428.39779",
-    "xknxproject_version": "2.1.0",
+    "xknxproject_version": "3.0.0",
     "language_code": "de-DE"
   },
   "communication_objects": {
@@ -19,10 +19,12 @@
       "function_text": "Messwert empfangen",
       "description": "",
       "device_address": "1.1.1",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,
@@ -41,10 +43,12 @@
       "function_text": "Temperaturwert empfangen",
       "description": "",
       "device_address": "1.1.1",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,
@@ -63,10 +67,12 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.1",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,
@@ -85,10 +91,12 @@
       "function_text": "Temperaturwert empfangen",
       "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,
@@ -107,10 +115,12 @@
       "function_text": "Sollwert vorgeben",
       "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,
@@ -129,10 +139,12 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.2",
-      "dpt": {
-        "main": 9,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 9,
+          "sub": 1
+        }
+      ],
       "object_size": "2 Bytes",
       "flags": {
         "read": false,

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -8,7 +8,7 @@
     "created_by": "ETS5",
     "schema_version": "20",
     "tool_version": "5.7.1428.39779",
-    "xknxproject_version": "2.1.0",
+    "xknxproject_version": "3.0.0",
     "language_code": null
   },
   "communication_objects": {
@@ -19,7 +19,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": null,
+      "dpts": [],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -38,7 +38,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": null,
+      "dpts": [],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -57,10 +57,12 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": {
-        "main": 1,
-        "sub": 8
-      },
+      "dpts": [
+        {
+          "main": 1,
+          "sub": 8
+        }
+      ],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -79,10 +81,12 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": {
-        "main": 1,
-        "sub": 8
-      },
+      "dpts": [
+        {
+          "main": 1,
+          "sub": 8
+        }
+      ],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -101,7 +105,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": null,
+      "dpts": [],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -120,10 +124,12 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": {
-        "main": 1,
-        "sub": 8
-      },
+      "dpts": [
+        {
+          "main": 1,
+          "sub": 8
+        }
+      ],
       "object_size": "1 Bit",
       "flags": {
         "read": false,
@@ -142,10 +148,12 @@
       "function_text": "Wind alarm no. 1",
       "description": "",
       "device_address": "1.1.5",
-      "dpt": {
-        "main": 1,
-        "sub": 1
-      },
+      "dpts": [
+        {
+          "main": 1,
+          "sub": 1
+        }
+      ],
       "object_size": "1 Bit",
       "flags": {
         "read": false,

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,18 +1,18 @@
 """Test utilities."""
 import pytest
 
-from xknxproject.util import parse_dpt_type
+from xknxproject.util import get_dpt_type, parse_dpt_types
 
 
 @pytest.mark.parametrize(
     ("dpt_string", "expected"),
     [
         ("DPT-1", {"main": 1, "sub": None}),
-        ("DPT-1 DPST-1-1", {"main": 1, "sub": 1}),
-        ("DPT-7 DPST-7-1", {"main": 7, "sub": 1}),
+        ("DPT-1 DPST-1-1", {"main": 1, "sub": None}),
+        ("DPT-7 DPST-7-1", {"main": 7, "sub": None}),
         ("DPST-5-1", {"main": 5, "sub": 1}),
-        ("DPT-1 DPT-5", {"main": 5, "sub": None}),
-        ("DPT-14 DPST-14-1", {"main": 14, "sub": 1}),
+        ("DPT-1 DPT-5", {"main": 1, "sub": None}),
+        ("DPT-14 DPST-14-1", {"main": 14, "sub": None}),
         ("DPST-6-10", {"main": 6, "sub": 10}),
         ("Wrong", None),
         ("DPT-Wrong", None),
@@ -22,6 +22,29 @@ from xknxproject.util import parse_dpt_type
         (None, None),
     ],
 )
-def test_parse_dpt_type(dpt_string, expected):
-    """Test parsing of DPT from ETS project."""
-    assert parse_dpt_type(dpt_string) == expected
+def test_get_dpt_type(dpt_string, expected):
+    """Test parsing single DPT from ETS project."""
+    assert get_dpt_type(dpt_string) == expected
+
+
+@pytest.mark.parametrize(
+    ("dpt_string", "expected"),
+    [
+        ("DPT-1", [{"main": 1, "sub": None}]),
+        ("DPT-1 DPST-1-1", [{"main": 1, "sub": None}, {"main": 1, "sub": 1}]),
+        ("DPT-7 DPST-7-1", [{"main": 7, "sub": None}, {"main": 7, "sub": 1}]),
+        ("DPST-5-1", [{"main": 5, "sub": 1}]),
+        ("DPT-1 DPT-5", [{"main": 1, "sub": None}, {"main": 5, "sub": None}]),
+        ("DPT-14 DPST-14-1", [{"main": 14, "sub": None}, {"main": 14, "sub": 1}]),
+        ("DPST-6-10", [{"main": 6, "sub": 10}]),
+        ("Wrong", []),
+        ("DPT-Wrong", []),
+        ("DPST-1-Wrong", []),
+        ("DPST-5", []),
+        ([], []),
+        (None, []),
+    ],
+)
+def test_parse_dpt_types(dpt_string, expected):
+    """Test parsing list of DPT from ETS project."""
+    assert parse_dpt_types(dpt_string) == expected

--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -8,7 +8,7 @@ from xml.etree import ElementTree
 from zipfile import Path
 
 from xknxproject.models import ComObject, ComObjectRef, DeviceInstance
-from xknxproject.util import parse_dpt_type, parse_xml_flag
+from xknxproject.util import parse_dpt_types, parse_xml_flag
 
 _LOGGER = logging.getLogger("xknxproject.log")
 
@@ -139,7 +139,7 @@ class ApplicationProgramLoader:
             transmit_flag=parse_xml_flag(elem.get("TransmitFlag"), False),
             update_flag=parse_xml_flag(elem.get("UpdateFlag"), False),
             read_on_init_flag=parse_xml_flag(elem.get("ReadOnInitFlag"), False),
-            datapoint_type=parse_dpt_type(elem.get("DatapointType")),
+            datapoint_types=parse_dpt_types(elem.get("DatapointType")),
         )
 
     @staticmethod
@@ -161,7 +161,7 @@ class ApplicationProgramLoader:
             transmit_flag=parse_xml_flag(elem.get("TransmitFlag")),
             update_flag=parse_xml_flag(elem.get("UpdateFlag")),
             read_on_init_flag=parse_xml_flag(elem.get("ReadOnInitFlag")),
-            datapoint_type=parse_dpt_type(elem.get("DatapointType")),
+            datapoint_types=parse_dpt_types(elem.get("DatapointType")),
         )
 
     @staticmethod

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -14,7 +14,7 @@ from xknxproject.models import (
     XMLProjectInformation,
     XMLSpace,
 )
-from xknxproject.util import parse_dpt_type, parse_xml_flag
+from xknxproject.util import get_dpt_type, parse_dpt_types, parse_xml_flag
 from xknxproject.zip import KNXProjContents
 
 
@@ -85,7 +85,7 @@ class _GroupAddressLoader:
             address=group_address_element.get("Address", ""),
             project_uid=int(group_address_element.get("Puid")),  # type: ignore[arg-type]
             description=group_address_element.get("Description", ""),
-            dpt=parse_dpt_type(group_address_element.get("DatapointType")),
+            dpt=get_dpt_type(group_address_element.get("DatapointType")),
         )
 
 
@@ -191,7 +191,7 @@ class _TopologyLoader:
             transmit_flag=parse_xml_flag(com_object.get("TransmitFlag")),
             update_flag=parse_xml_flag(com_object.get("UpdateFlag")),
             read_on_init_flag=parse_xml_flag(com_object.get("ReadOnInitFlag")),
-            datapoint_type=parse_dpt_type(com_object.get("DatapointType")),
+            datapoint_types=parse_dpt_types(com_object.get("DatapointType")),
             description=com_object.get("Description"),
             links=links.split(" "),
         )

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -31,7 +31,7 @@ class CommunicationObject(TypedDict):
     function_text: str
     description: str
     device_address: str
-    dpt: DPTType | None
+    dpts: list[DPTType]
     object_size: str
     group_address_links: list[str]
     flags: Flags

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -136,7 +136,7 @@ class ComObjectInstanceRef:
     transmit_flag: bool | None  # "TransmitFlag" - knx:Enable_t
     update_flag: bool | None  # "UpdateFlag" - knx:Enable_t
     read_on_init_flag: bool | None  # "ReadOnInitFlag" - knx:Enable_t
-    datapoint_type: DPTType | None  # "DataPointType" - knx:IDREFS
+    datapoint_types: list[DPTType]  # "DataPointType" - knx:IDREFS
     description: str | None  # "Description" - language dependent
     links: list[str] | None  # "Links" - knx:RELIDREFS
 
@@ -176,8 +176,8 @@ class ComObjectInstanceRef:
             self.update_flag = com_object.update_flag
         if self.read_on_init_flag is None:
             self.read_on_init_flag = com_object.read_on_init_flag
-        if self.datapoint_type is None:
-            self.datapoint_type = com_object.datapoint_type
+        if not self.datapoint_types:
+            self.datapoint_types = com_object.datapoint_types
         if isinstance(com_object, ComObject):
             self.number = com_object.number
 
@@ -199,7 +199,7 @@ class ComObject:
         "transmit_flag",
         "update_flag",
         "read_on_init_flag",
-        "datapoint_type",
+        "datapoint_types",
     )
 
     # all items required in the XML
@@ -215,7 +215,7 @@ class ComObject:
     transmit_flag: bool  # "TransmitFlag" - knx:Enable_t
     update_flag: bool  # "UpdateFlag" - knx:Enable_t
     read_on_init_flag: bool  # "ReadOnInitFlag" - knx:Enable_t
-    datapoint_type: DPTType | None  # "DataPointType" - knx:IDREFS - optional
+    datapoint_types: list[DPTType]  # "DataPointType" - knx:IDREFS - optional
 
 
 @dataclass
@@ -235,7 +235,7 @@ class ComObjectRef:
         "transmit_flag",
         "update_flag",
         "read_on_init_flag",
-        "datapoint_type",
+        "datapoint_types",
     )
 
     identifier: str  # "Id" - xs:ID - required
@@ -250,7 +250,7 @@ class ComObjectRef:
     transmit_flag: bool | None  # "TransmitFlag" - knx:Enable_t
     update_flag: bool | None  # "UpdateFlag" - knx:Enable_t
     read_on_init_flag: bool | None  # "ReadOnInitFlag" - knx:Enable_t
-    datapoint_type: DPTType | None  # "DataPointType" - knx:IDREFS
+    datapoint_types: list[DPTType]  # "DataPointType" - knx:IDREFS
 
 
 @dataclass

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -70,7 +70,7 @@ class XMLParser:
                         function_text=com_object.function_text,  # type: ignore[typeddict-item]
                         description=com_object.description or "",
                         device_address=device.individual_address,
-                        dpt=com_object.datapoint_type,
+                        dpts=com_object.datapoint_types,
                         object_size=com_object.object_size,  # type: ignore[typeddict-item]
                         flags=Flags(
                             read=com_object.read_flag,  # type: ignore[typeddict-item]


### PR DESCRIPTION
Communication objects can have multiple valid DPTs so their key `dpt: DPTType | None` is changed to `dpts: list[DPTType]`.
GroupAddresses seem to only support a single DPT so they aren't changed.