### PR TITLE
Remove flake8 plugins and add pytest-icdiff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,6 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies:
-          - flake8-docstrings==1.6.0
-          - pydocstyle==6.0.0
         files: ^(xknxproject|examples|docs)/.+\.py$
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -2,11 +2,10 @@
 pre-commit==3.3.2
 isort==5.12.0
 flake8==6.0.0
-flake8-isort==6.0.0
-pydocstyle==6.3.0
 pylint==2.17.4
 pytest==7.3.1
 pytest-cov==4.1.0
+pytest-icdiff==0.6
 ruff==0.0.270
 setuptools==67.8.0
 tox==4.5.2


### PR DESCRIPTION
flake8 plugins and pydocstyle are superseded by ruff.
pytest-icdiff provides nice assertion diffs