### PR TITLE
Reuse universal wheel for all tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ setenv =
 commands =
     pytest --cov xknxproject --cov-report= {posargs}
 deps = -rrequirements_testing.txt
+package = wheel
+wheel_build_env = .pkg
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
This avoids having tox to build the package for every environment anew.
On my machine this reduces time tox needs to run from 32 seconds to 11 🚴💨