### PR TITLE
Unpin setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3"]
+requires = ["setuptools>=62.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
I am working on Python packaging in [nixpkgs](https://github.com/NixOS/nixpkgs), and we working on switching our builder to [`build`](https://pypa-build.readthedocs.io/en/latest/), and we want to leverage its stronger validation for build dependencies. Toward that end, would it be possible to relax the setuptools dependency in pyproject.toml?