### PR TITLE
Restructure parser module

### DIFF
--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -324,14 +324,8 @@ class XMLParser:
                 name=area.name, description=area.description, lines=lines_dict
             )
 
-        group_address_dict: dict[str, GroupAddress] = {}
-        for group_address in self.group_addresses:
-            _com_object_ids = [
-                com_object_id
-                for com_object_id, com_object in communication_objects.items()
-                if group_address.address in com_object["group_address_links"]
-            ]
-            group_address_dict[group_address.address] = GroupAddress(
+        group_address_dict: dict[str, GroupAddress] = {
+            group_address.address: GroupAddress(
                 name=group_address.name,
                 identifier=group_address.identifier,
                 raw_address=group_address.raw_address,
@@ -339,20 +333,27 @@ class XMLParser:
                 project_uid=group_address.project_uid,
                 dpt=group_address.dpt,
                 data_secure=bool(group_address.data_secure_key),
-                communication_object_ids=_com_object_ids,
+                communication_object_ids=[
+                    com_object_id
+                    for com_object_id, com_object in communication_objects.items()
+                    if group_address.address in com_object["group_address_links"]
+                ],
                 description=group_address.description,
                 comment=html.unescape(rtf_to_text(group_address.comment)),
             )
+            for group_address in self.group_addresses
+        }
 
         group_range_dict: dict[str, GroupRange] = _recursive_convert_group_range(
-            self.group_ranges, group_address_style=self.project_info.group_address_style
+            self.group_ranges, self.project_info.group_address_style
         )
 
         space_dict: dict[str, Space] = _recursive_convert_spaces(self.spaces)
 
-        functions_dict: dict[str, Function] = {}
-        for function in self.functions:
-            functions_dict[function.identifier] = _convert_functions(function)
+        functions_dict: dict[str, Function] = {
+            function.identifier: _convert_functions(function)
+            for function in self.functions
+        }
 
         info = ProjectInfo(
             project_id=self.project_info.project_id,

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -75,25 +75,24 @@ def _convert_functions(function: XMLFunction) -> Function:
     )
 
 
-def _recursive_convert_spaces(space: XMLSpace) -> Space:
+def _recursive_convert_spaces(spaces: list[XMLSpace]) -> dict[str, Space]:
     """Convert spaces to the final output format."""
-    subspaces: dict[str, Space] = {}
-    for subspace in space.spaces:
-        subspaces[subspace.name] = _recursive_convert_spaces(subspace)
-
-    return Space(
-        type=space.space_type.value,
-        identifier=space.identifier,
-        name=space.name,
-        usage_id=space.usage_id,
-        usage_text=space.usage_text,
-        number=space.number,
-        description=space.description,
-        project_uid=space.project_uid,
-        devices=space.devices,
-        spaces=subspaces,
-        functions=space.functions,
-    )
+    return {
+        space.name: Space(
+            type=space.space_type.value,
+            identifier=space.identifier,
+            name=space.name,
+            usage_id=space.usage_id,
+            usage_text=space.usage_text,
+            number=space.number,
+            description=space.description,
+            project_uid=space.project_uid,
+            devices=space.devices,
+            spaces=_recursive_convert_spaces(space.spaces),
+            functions=space.functions,
+        )
+        for space in spaces
+    }
 
 
 def _recursive_convert_group_range(
@@ -353,9 +352,7 @@ class XMLParser:
                 group_range, self.project_info.group_address_style
             )
 
-        space_dict: dict[str, Space] = {}
-        for space in self.spaces:
-            space_dict[space.name] = _recursive_convert_spaces(space)
+        space_dict: dict[str, Space] = _recursive_convert_spaces(self.spaces)
 
         functions_dict: dict[str, Function] = {}
         for function in self.functions:


### PR DESCRIPTION
for better readability.

- Order of methods resembles execution order
- Internal functions and methods are prefixed with `_`
- Helper functions moved out of XMLParser class
- Use more dict comprehensions
- Use recursive conversion also for top level