### PR TITLE
Parse device channels

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -231,11 +231,11 @@
       "channels": {
         "MD-2_M-1_MI-1_CH-1": {
           "identifier": "MD-2_M-1_MI-1_CH-1",
-          "name": "Kanal {{ChNo}}: Wohnzimmer"
+          "name": "Kanal A: Wohnzimmer"
         },
         "MD-2_M-2_MI-1_CH-1": {
           "identifier": "MD-2_M-2_MI-1_CH-1",
-          "name": "Kanal {{ChNo}}: Küche"
+          "name": "Kanal B: Küche"
         },
         "CH-9": {
           "identifier": "CH-9",
@@ -256,7 +256,7 @@
       "channels": {
         "MD-2_M-1_MI-1_CH-1": {
           "identifier": "MD-2_M-1_MI-1_CH-1",
-          "name": "Kanal {{ChNo}}: Bad"
+          "name": "Kanal A: Bad"
         },
         "CH-9": {
           "identifier": "CH-9",

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -19,6 +19,7 @@
       "function_text": "Messwert empfangen",
       "description": "",
       "device_address": "1.1.1",
+      "channel": null,
       "dpts": [
         {
           "main": 9,
@@ -45,6 +46,7 @@
       "function_text": "Temperaturwert empfangen",
       "description": "",
       "device_address": "1.1.1",
+      "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
           "main": 9,
@@ -71,6 +73,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.1",
+      "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
           "main": 9,
@@ -98,6 +101,7 @@
       "function_text": "Temperaturwert empfangen",
       "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
+      "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
           "main": 9,
@@ -124,6 +128,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
+      "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
           "main": 9,
@@ -151,6 +156,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.2",
+      "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
           "main": 9,
@@ -221,7 +227,21 @@
         "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3",
         "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1",
         "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3"
-      ]
+      ],
+      "channels": {
+        "MD-2_M-1_MI-1_CH-1": {
+          "identifier": "MD-2_M-1_MI-1_CH-1",
+          "name": "Kanal {{ChNo}}: Wohnzimmer"
+        },
+        "MD-2_M-2_MI-1_CH-1": {
+          "identifier": "MD-2_M-2_MI-1_CH-1",
+          "name": "Kanal {{ChNo}}: Küche"
+        },
+        "CH-9": {
+          "identifier": "CH-9",
+          "name": "Szenen"
+        }
+      }
     },
     "1.1.2": {
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
@@ -232,7 +252,17 @@
       "project_uid": 13,
       "communication_object_ids": [
         "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"
-      ]
+      ],
+      "channels": {
+        "MD-2_M-1_MI-1_CH-1": {
+          "identifier": "MD-2_M-1_MI-1_CH-1",
+          "name": "Kanal {{ChNo}}: Bad"
+        },
+        "CH-9": {
+          "identifier": "CH-9",
+          "name": "Szenen"
+        }
+      }
     }
   },
   "group_addresses": {

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -19,6 +19,7 @@
       "function_text": "Switch On/Off",
       "description": "",
       "device_address": "0.0.1",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -45,6 +46,7 @@
       "function_text": "State",
       "description": "",
       "device_address": "0.0.1",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -71,6 +73,7 @@
       "function_text": "State",
       "description": "",
       "device_address": "0.0.1",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -97,6 +100,7 @@
       "function_text": "Behang Auf-Ab fahren",
       "description": "",
       "device_address": "0.0.2",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -124,6 +128,7 @@
       "function_text": "Lamellenverst./Stopp Auf-Ab",
       "description": "",
       "device_address": "0.0.2",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -173,7 +178,8 @@
         "0.0.1/M-0083_A-0013-11-A9D6_O-0_R-10000",
         "0.0.1/M-0083_A-0013-11-A9D6_O-5_R-10005",
         "0.0.1/M-0083_A-0013-11-A9D6_O-13_R-4"
-      ]
+      ],
+      "channels": {}
     },
     "0.0.2": {
       "name": "JRA/S4.230.5.1 Jal./Rol.Akt.Fahrzt.man.4f,230V,REG",
@@ -185,7 +191,8 @@
       "communication_object_ids": [
         "0.0.2/M-0002_A-A061-14-BE27_O-10_R-485",
         "0.0.2/M-0002_A-A061-14-BE27_O-71_R-1506"
-      ]
+      ],
+      "channels": {}
     }
   },
   "group_addresses": {

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -605,51 +605,51 @@
       "channels": {
         "MD-1_M-13_MI-1_CH-80": {
           "identifier": "MD-1_M-13_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 1 (...)"
         },
         "MD-1_M-8_MI-1_CH-80": {
           "identifier": "MD-1_M-8_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 2 (...)"
         },
         "MD-1_M-1_MI-1_CH-80": {
           "identifier": "MD-1_M-1_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 3 (...)"
         },
         "MD-1_M-2_MI-1_CH-80": {
           "identifier": "MD-1_M-2_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 4 (...)"
         },
         "MD-1_M-6_MI-1_CH-80": {
           "identifier": "MD-1_M-6_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 5 (...)"
         },
         "MD-1_M-3_MI-1_CH-80": {
           "identifier": "MD-1_M-3_MI-1_CH-80",
-          "name": "Ventilausgang {{MDA_Number}} (...)"
+          "name": "Ventilausgang 6 (...)"
         },
         "MD-2_M-20_MI-1_CH-81": {
           "identifier": "MD-2_M-20_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 1 (...)"
         },
         "MD-2_M-4_MI-1_CH-81": {
           "identifier": "MD-2_M-4_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 2 (...)"
         },
         "MD-2_M-9_MI-1_CH-81": {
           "identifier": "MD-2_M-9_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 3 (...)"
         },
         "MD-2_M-10_MI-1_CH-81": {
           "identifier": "MD-2_M-10_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 4 (...)"
         },
         "MD-2_M-11_MI-1_CH-81": {
           "identifier": "MD-2_M-11_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 5 (...)"
         },
         "MD-2_M-12_MI-1_CH-81": {
           "identifier": "MD-2_M-12_MI-1_CH-81",
-          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+          "name": "Raumtemperaturregler 6 (...)"
         }
       }
     }

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -19,6 +19,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -45,6 +46,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -71,6 +73,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -97,6 +100,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -123,6 +127,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -149,6 +154,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -175,6 +181,7 @@
       "function_text": "Wind alarm no. 1",
       "description": "",
       "device_address": "1.1.5",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -201,6 +208,7 @@
       "function_text": "Output value",
       "description": "2-byte generic",
       "device_address": "1.1.6",
+      "channel": null,
       "dpts": [],
       "object_size": "2 Bytes",
       "flags": {
@@ -222,6 +230,7 @@
       "function_text": "Measured value outside range",
       "description": "1-bit undefined DPT",
       "device_address": "1.1.6",
+      "channel": null,
       "dpts": [
         {
           "main": 1,
@@ -248,6 +257,7 @@
       "function_text": "Output value",
       "description": "2-byte DPT 9 any",
       "device_address": "1.1.6",
+      "channel": null,
       "dpts": [
         {
           "main": 9,
@@ -368,6 +378,7 @@
       "function_text": "Output value",
       "description": "2-byte DPT 9 generic",
       "device_address": "1.1.6",
+      "channel": null,
       "dpts": [
         {
           "main": 9,
@@ -395,6 +406,7 @@
       "function_text": "Command value - Heating",
       "description": "",
       "device_address": "1.1.7",
+      "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
           "main": 5,
@@ -421,6 +433,7 @@
       "function_text": "Setpoint temperature - Active operating mode",
       "description": "",
       "device_address": "1.1.7",
+      "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
           "main": 9,
@@ -447,6 +460,7 @@
       "function_text": "Setpoint temperature - Active operating mode - Status",
       "description": "",
       "device_address": "1.1.7",
+      "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
           "main": 9,
@@ -473,6 +487,7 @@
       "function_text": "Room temperature - Measured value 1",
       "description": "",
       "device_address": "1.1.7",
+      "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
           "main": 9,
@@ -538,7 +553,8 @@
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.0",
       "project_uid": 25,
-      "communication_object_ids": []
+      "communication_object_ids": [],
+      "channels": {}
     },
     "1.1.5": {
       "name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
@@ -555,7 +571,8 @@
         "1.1.5/O-100_R-1577",
         "1.1.5/O-101_R-1578",
         "1.1.5/O-4_R-1417"
-      ]
+      ],
+      "channels": {}
     },
     "1.1.6": {
       "name": "AE/S4.2 Analogue Input,4-fold,MDRC",
@@ -569,7 +586,8 @@
         "1.1.6/O-20_R-8108",
         "1.1.6/O-9_R-9073",
         "1.1.6/O-18_R-7994"
-      ]
+      ],
+      "channels": {}
     },
     "1.1.7": {
       "name": "Heating actuator 6-gang with controller",
@@ -583,7 +601,57 @@
         "1.1.7/MD-2_M-20_MI-1_O-5-0_R-17",
         "1.1.7/MD-2_M-20_MI-1_O-5-10_R-18",
         "1.1.7/MD-2_M-20_MI-1_O-7-1_R-45"
-      ]
+      ],
+      "channels": {
+        "MD-1_M-13_MI-1_CH-80": {
+          "identifier": "MD-1_M-13_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-1_M-8_MI-1_CH-80": {
+          "identifier": "MD-1_M-8_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-1_M-1_MI-1_CH-80": {
+          "identifier": "MD-1_M-1_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-1_M-2_MI-1_CH-80": {
+          "identifier": "MD-1_M-2_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-1_M-6_MI-1_CH-80": {
+          "identifier": "MD-1_M-6_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-1_M-3_MI-1_CH-80": {
+          "identifier": "MD-1_M-3_MI-1_CH-80",
+          "name": "Ventilausgang {{MDA_Number}} (...)"
+        },
+        "MD-2_M-20_MI-1_CH-81": {
+          "identifier": "MD-2_M-20_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        },
+        "MD-2_M-4_MI-1_CH-81": {
+          "identifier": "MD-2_M-4_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        },
+        "MD-2_M-9_MI-1_CH-81": {
+          "identifier": "MD-2_M-9_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        },
+        "MD-2_M-10_MI-1_CH-81": {
+          "identifier": "MD-2_M-10_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        },
+        "MD-2_M-11_MI-1_CH-81": {
+          "identifier": "MD-2_M-11_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        },
+        "MD-2_M-12_MI-1_CH-81": {
+          "identifier": "MD-2_M-12_MI-1_CH-81",
+          "name": "Raumtemperaturregler {{MDA_Number}} (...)"
+        }
+      }
     }
   },
   "group_addresses": {

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -246,15 +246,17 @@ class _TopologyLoader:
             manufacturer=product_ref.split("_", 1)[0],
         )
 
-        for sub_node in device_element:
-            if sub_node.tag.endswith("AdditionalAddresses"):
-                for address_node in sub_node:
-                    if _address := address_node.get("Address"):
-                        device.additional_addresses.append(_address)
-            if sub_node.tag.endswith("ComObjectInstanceRefs"):
-                for com_object in sub_node:
-                    if instance := self._create_com_object_instance(com_object):
-                        device.com_object_instance_refs.append(instance)
+        for address_elem in device_element.findall("{*}AdditionalAddresses/{*}Address"):
+            if _address := address_elem.get("Address"):
+                device.additional_addresses.append(_address)
+
+        for com_obj_inst_ref_elem in device_element.findall(
+            "{*}ComObjectInstanceRefs/{*}ComObjectInstanceRef"
+        ):
+            if com_obj_inst_ref := self._create_com_object_instance(
+                com_obj_inst_ref_elem
+            ):
+                device.com_object_instance_refs.append(com_obj_inst_ref)
 
         return device
 

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -5,6 +5,7 @@ import re
 from xml.etree import ElementTree
 
 from xknxproject.models import (
+    ChannelNode,
     ComObjectInstanceRef,
     DeviceInstance,
     GroupAddressStyle,
@@ -258,6 +259,16 @@ class _TopologyLoader:
             ):
                 device.com_object_instance_refs.append(com_obj_inst_ref)
 
+        for channel_node_elem in device_element.findall(
+            "{*}GroupObjectTree/{*}Nodes/{*}Node[@Type='Channel']"
+        ):
+            device.channels.append(
+                ChannelNode(
+                    ref_id=channel_node_elem.get("RefId"),  # type: ignore[arg-type]
+                    name=channel_node_elem.get("Text", ""),
+                )
+            )
+
         return device
 
     @staticmethod
@@ -309,6 +320,7 @@ class _TopologyLoader:
             read_on_init_flag=parse_xml_flag(com_object.get("ReadOnInitFlag")),
             datapoint_types=parse_dpt_types(com_object.get("DatapointType")),
             description=com_object.get("Description"),
+            channel=com_object.get("ChannelId"),
             links=links,
         )
 

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -10,6 +10,8 @@ from xknxproject.models import (
     DeviceInstance,
     GroupAddressStyle,
     KNXMasterData,
+    ModuleInstance,
+    ModuleInstanceArgument,
     SpaceType,
     XMLArea,
     XMLFunction,
@@ -248,6 +250,13 @@ class _TopologyLoader:
             )
             if (com_obj_inst_ref := self._create_com_object_instance(elem)) is not None
         ]
+        module_instances = [
+            module_instance
+            for mi_elem in device_element.findall(
+                "{*}ModuleInstances/{*}ModuleInstance"
+            )
+            if (module_instance := self._create_module_instance(mi_elem)) is not None
+        ]
         channels = [
             ChannelNode(
                 ref_id=channel_node_elem.get("RefId"),  # type: ignore[arg-type]
@@ -271,6 +280,7 @@ class _TopologyLoader:
             additional_addresses=additional_addresses,
             channels=channels,
             com_object_instance_refs=com_obj_inst_refs,
+            module_instances=module_instances,
         )
 
     @staticmethod
@@ -324,6 +334,24 @@ class _TopologyLoader:
             description=com_object.get("Description"),
             channel=com_object.get("ChannelId"),
             links=links,
+        )
+
+    def _create_module_instance(
+        self,
+        module_instance_elem: ElementTree.Element,
+    ) -> ModuleInstance | None:
+        """Create ComObjectInstanceRef."""
+        module_arguments = [
+            ModuleInstanceArgument(
+                ref_id=arg.get("RefId"),  # type: ignore[arg-type]
+                value=arg.get("Value"),  # type: ignore[arg-type]
+            )
+            for arg in module_instance_elem.findall("{*}Arguments/{*}Argument")
+        ]
+        return ModuleInstance(
+            identifier=module_instance_elem.get("Id"),  # type: ignore[arg-type]
+            ref_id=module_instance_elem.get("RefId"),  # type: ignore[arg-type]
+            arguments=module_arguments,
         )
 
 

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -24,6 +24,8 @@ from .models import (
     DeviceInstance,
     HardwareToPrograms,
     KNXMasterData,
+    ModuleInstance,
+    ModuleInstanceArgument,
     Product,
     TranslationsType,
     XMLArea,

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -2,6 +2,7 @@
 # flake8: noqa
 from .knxproject import (
     Area,
+    Channel,
     CommunicationObject,
     Device,
     DPTType,
@@ -16,6 +17,7 @@ from .knxproject import (
     Space,
 )
 from .models import (
+    ChannelNode,
     ComObject,
     ComObjectInstanceRef,
     ComObjectRef,

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -31,6 +31,7 @@ class CommunicationObject(TypedDict):
     function_text: str
     description: str
     device_address: str
+    channel: str | None
     dpts: list[DPTType]
     object_size: str
     group_address_links: list[str]
@@ -47,6 +48,14 @@ class Device(TypedDict):
     individual_address: str
     project_uid: int | None
     communication_object_ids: list[str]
+    channels: dict[str, Channel]  # id: Channel
+
+
+class Channel(TypedDict):
+    """Channel typed dict."""
+
+    identifier: str
+    name: str
 
 
 class Line(TypedDict):

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -128,9 +128,9 @@ class DeviceInstance:
         hardware_program_ref: str,
         line: XMLLine,
         manufacturer: str,
-        additional_addresses: list[str] | None = None,
-        channels: list[ChannelNode] | None = None,
-        com_object_instance_refs: list[ComObjectInstanceRef] | None = None,
+        additional_addresses: list[str],
+        channels: list[ChannelNode],
+        com_object_instance_refs: list[ComObjectInstanceRef],
         com_objects: list[ComObject] | None = None,
     ):
         """Initialize a Device Instance."""
@@ -146,9 +146,9 @@ class DeviceInstance:
         self.area_address = line.area.address  # used for sorting
         self.line_address = line.address  # used for sorting
         self.manufacturer = manufacturer
-        self.additional_addresses = additional_addresses or []
-        self.channels: list[ChannelNode] = channels or []
-        self.com_object_instance_refs = com_object_instance_refs or []
+        self.additional_addresses = additional_addresses
+        self.channels: list[ChannelNode] = channels
+        self.com_object_instance_refs = com_object_instance_refs
         self.com_objects = com_objects or []
         self.application_program_ref: str | None = None
 

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -129,6 +129,7 @@ class DeviceInstance:
         line: XMLLine,
         manufacturer: str,
         additional_addresses: list[str] | None = None,
+        channels: list[ChannelNode] | None = None,
         com_object_instance_refs: list[ComObjectInstanceRef] | None = None,
         com_objects: list[ComObject] | None = None,
     ):
@@ -146,6 +147,7 @@ class DeviceInstance:
         self.line_address = line.address  # used for sorting
         self.manufacturer = manufacturer
         self.additional_addresses = additional_addresses or []
+        self.channels: list[ChannelNode] = channels or []
         self.com_object_instance_refs = com_object_instance_refs or []
         self.com_objects = com_objects or []
         self.application_program_ref: str | None = None
@@ -169,6 +171,14 @@ class DeviceInstance:
 
 
 @dataclass
+class ChannelNode:
+    """Class that represents a Node with Type Channel."""
+
+    ref_id: str
+    name: str
+
+
+@dataclass
 class ComObjectInstanceRef:
     """Class that represents a ComObjectInstanceRef instance."""
 
@@ -186,6 +196,7 @@ class ComObjectInstanceRef:
     read_on_init_flag: bool | None  # "ReadOnInitFlag" - knx:Enable_t
     datapoint_types: list[DPTType]  # "DataPointType" - knx:IDREFS
     description: str | None  # "Description" - language dependent
+    channel: str | None  # "ChannelId" - knx:IDREFS
     links: list[str] | None  # "Links" - knx:RELIDREFS
 
     # resolved via Hardware.xml from the containing DeviceInstance

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -17,6 +17,7 @@ from xknxproject.loader import (
 from xknxproject.models import (
     MEDIUM_TYPES,
     Area,
+    Channel,
     CommunicationObject,
     Device,
     DeviceInstance,
@@ -283,6 +284,7 @@ class XMLParser:
                     function_text=com_object.function_text,  # type: ignore[typeddict-item]
                     description=com_object.description or "",
                     device_address=device.individual_address,
+                    channel=com_object.channel,
                     dpts=com_object.datapoint_types,
                     object_size=com_object.object_size,  # type: ignore[typeddict-item]
                     flags=Flags(
@@ -305,6 +307,12 @@ class XMLParser:
                 individual_address=device.individual_address,
                 project_uid=device.project_uid,
                 communication_object_ids=device_com_objects,
+                channels={
+                    channel.ref_id: Channel(
+                        identifier=channel.ref_id, name=channel.name
+                    )
+                    for channel in device.channels
+                },
             )
 
         topology_dict: dict[str, Area] = {}

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -212,6 +212,8 @@ class XMLParser:
                 com_object.resolve_com_object_ref_id(
                     application_program_ref, self.knx_proj_contents
                 )
+            for module_instance_argument in device.module_instance_arguments():
+                module_instance_argument.complete_ref_id(application_program_ref)
 
         application_programs = (
             ApplicationProgramLoader.get_application_program_files_for_devices(
@@ -226,6 +228,8 @@ class XMLParser:
                 devices=devices,
                 language_code=self.language_code,
             )
+        for device in self.devices:
+            device.complete_channel_placeholders()
 
     def _sort(self) -> None:
         """Sort loaded structures as XML content is sorted by creation time."""


### PR DESCRIPTION
This adds a channel identifier to communication objects and channel informations (currently only name) to devices.

- [x] Resolve Module instance arguments in name text placeholders.
`"name": "Kanal {{ChNo}}: Wohnzimmer"` this should read "Kanal A: Wohnzimmer"