### PR TITLE
Add application program identifier and module information

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -220,6 +220,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.1",
+      "application_program": "M-0083_A-013A-32-DCC1",
       "project_uid": 12,
       "communication_object_ids": [
         "1.1.1/O-334_R-21",
@@ -249,6 +250,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.2",
+      "application_program": "M-0083_A-013A-32-DCC1",
       "project_uid": 13,
       "communication_object_ids": [
         "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -20,6 +20,7 @@
       "description": "",
       "device_address": "1.1.1",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -48,6 +49,10 @@
       "description": "",
       "device_address": "1.1.1",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 1
+      },
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
@@ -76,6 +81,10 @@
       "description": "",
       "device_address": "1.1.1",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 2
+      },
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
@@ -105,6 +114,10 @@
       "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 1
+      },
       "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
@@ -133,6 +146,10 @@
       "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 2
+      },
       "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
@@ -162,6 +179,10 @@
       "description": "",
       "device_address": "1.1.2",
       "device_application": "M-0083_A-013A-32-DCC1",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 2
+      },
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -19,6 +19,7 @@
       "function_text": "Messwert empfangen",
       "description": "",
       "device_address": "1.1.1",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": null,
       "dpts": [
         {
@@ -46,6 +47,7 @@
       "function_text": "Temperaturwert empfangen",
       "description": "",
       "device_address": "1.1.1",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
@@ -73,6 +75,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.1",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
@@ -101,6 +104,7 @@
       "function_text": "Temperaturwert empfangen",
       "description": "Beschreibung KO 41",
       "device_address": "1.1.1",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
@@ -128,6 +132,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "Beschreibung KO 42 (U-Flag)",
       "device_address": "1.1.1",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": "MD-2_M-2_MI-1_CH-1",
       "dpts": [
         {
@@ -156,6 +161,7 @@
       "function_text": "Sollwert vorgeben",
       "description": "",
       "device_address": "1.1.2",
+      "device_application": "M-0083_A-013A-32-DCC1",
       "channel": "MD-2_M-1_MI-1_CH-1",
       "dpts": [
         {
@@ -220,7 +226,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.1",
-      "application_program": "M-0083_A-013A-32-DCC1",
+      "application": "M-0083_A-013A-32-DCC1",
       "project_uid": 12,
       "communication_object_ids": [
         "1.1.1/O-334_R-21",
@@ -250,7 +256,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.2",
-      "application_program": "M-0083_A-013A-32-DCC1",
+      "application": "M-0083_A-013A-32-DCC1",
       "project_uid": 13,
       "communication_object_ids": [
         "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -173,6 +173,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "0.0.1",
+      "application_program": "M-0083_A-0013-11-A9D6",
       "project_uid": null,
       "communication_object_ids": [
         "0.0.1/M-0083_A-0013-11-A9D6_O-0_R-10000",
@@ -187,6 +188,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "0.0.2",
+      "application_program": "M-0002_A-A061-14-BE27",
       "project_uid": null,
       "communication_object_ids": [
         "0.0.2/M-0002_A-A061-14-BE27_O-10_R-485",

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -19,6 +19,7 @@
       "function_text": "Switch On/Off",
       "description": "",
       "device_address": "0.0.1",
+      "device_application": "M-0083_A-0013-11-A9D6",
       "channel": null,
       "dpts": [
         {
@@ -46,6 +47,7 @@
       "function_text": "State",
       "description": "",
       "device_address": "0.0.1",
+      "device_application": "M-0083_A-0013-11-A9D6",
       "channel": null,
       "dpts": [
         {
@@ -73,6 +75,7 @@
       "function_text": "State",
       "description": "",
       "device_address": "0.0.1",
+      "device_application": "M-0083_A-0013-11-A9D6",
       "channel": null,
       "dpts": [
         {
@@ -100,6 +103,7 @@
       "function_text": "Behang Auf-Ab fahren",
       "description": "",
       "device_address": "0.0.2",
+      "device_application": "M-0002_A-A061-14-BE27",
       "channel": null,
       "dpts": [
         {
@@ -128,6 +132,7 @@
       "function_text": "Lamellenverst./Stopp Auf-Ab",
       "description": "",
       "device_address": "0.0.2",
+      "device_application": "M-0002_A-A061-14-BE27",
       "channel": null,
       "dpts": [
         {
@@ -173,7 +178,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "0.0.1",
-      "application_program": "M-0083_A-0013-11-A9D6",
+      "application": "M-0083_A-0013-11-A9D6",
       "project_uid": null,
       "communication_object_ids": [
         "0.0.1/M-0083_A-0013-11-A9D6_O-0_R-10000",
@@ -188,7 +193,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "0.0.2",
-      "application_program": "M-0002_A-A061-14-BE27",
+      "application": "M-0002_A-A061-14-BE27",
       "project_uid": null,
       "communication_object_ids": [
         "0.0.2/M-0002_A-A061-14-BE27_O-10_R-485",

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -20,6 +20,7 @@
       "description": "",
       "device_address": "0.0.1",
       "device_application": "M-0083_A-0013-11-A9D6",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -48,6 +49,7 @@
       "description": "",
       "device_address": "0.0.1",
       "device_application": "M-0083_A-0013-11-A9D6",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -76,6 +78,7 @@
       "description": "",
       "device_address": "0.0.1",
       "device_application": "M-0083_A-0013-11-A9D6",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -104,6 +107,7 @@
       "description": "",
       "device_address": "0.0.2",
       "device_application": "M-0002_A-A061-14-BE27",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -133,6 +137,7 @@
       "description": "",
       "device_address": "0.0.2",
       "device_application": "M-0002_A-A061-14-BE27",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -20,6 +20,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -48,6 +49,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -76,6 +78,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -104,6 +107,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -132,6 +136,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -160,6 +165,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -188,6 +194,7 @@
       "description": "",
       "device_address": "1.1.5",
       "device_application": "M-0002_A-A066-14-550B",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -216,6 +223,7 @@
       "description": "2-byte generic",
       "device_address": "1.1.6",
       "device_application": "M-0002_A-A01B-14-1B7C",
+      "module_def": null,
       "channel": null,
       "dpts": [],
       "object_size": "2 Bytes",
@@ -239,6 +247,7 @@
       "description": "1-bit undefined DPT",
       "device_address": "1.1.6",
       "device_application": "M-0002_A-A01B-14-1B7C",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -267,6 +276,7 @@
       "description": "2-byte DPT 9 any",
       "device_address": "1.1.6",
       "device_application": "M-0002_A-A01B-14-1B7C",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -389,6 +399,7 @@
       "description": "2-byte DPT 9 generic",
       "device_address": "1.1.6",
       "device_application": "M-0002_A-A01B-14-1B7C",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {
@@ -418,6 +429,10 @@
       "description": "",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 2
+      },
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -446,6 +461,10 @@
       "description": "",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 0
+      },
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -474,6 +493,10 @@
       "description": "",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 10
+      },
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -502,6 +525,10 @@
       "description": "",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 1
+      },
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -530,6 +557,10 @@
       "description": "",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": {
+        "definition": "MD-2",
+        "root_number": 1
+      },
       "channel": "MD-2_M-4_MI-1_CH-81",
       "dpts": [
         {
@@ -558,6 +589,7 @@
       "description": "no-channel GO",
       "device_address": "1.1.7",
       "device_application": "M-0008_A-20E0-21-9997-O000A",
+      "module_def": null,
       "channel": null,
       "dpts": [
         {

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -606,6 +606,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.0",
+      "application_program": "M-0083_A-0139-22-F35B-O0072",
       "project_uid": 25,
       "communication_object_ids": [],
       "channels": {}
@@ -616,6 +617,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.5",
+      "application_program": "M-0002_A-A066-14-550B",
       "project_uid": 31,
       "communication_object_ids": [
         "1.1.5/O-40_R-1433",
@@ -634,6 +636,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.6",
+      "application_program": "M-0002_A-A01B-14-1B7C",
       "project_uid": 49,
       "communication_object_ids": [
         "1.1.6/O-0_R-665",
@@ -649,6 +652,7 @@
       "description": "",
       "manufacturer_name": "GIRA Giersiepen",
       "individual_address": "1.1.7",
+      "application_program": "M-0008_A-20E0-21-9997-O000A",
       "project_uid": 60,
       "communication_object_ids": [
         "1.1.7/MD-2_M-20_MI-1_O-2-2_R-3",

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -19,6 +19,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -46,6 +47,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -73,6 +75,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -100,6 +103,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -127,6 +131,7 @@
       "function_text": "Move blinds/shutter up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -154,6 +159,7 @@
       "function_text": "Slat adjustm./stop up-down",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -181,6 +187,7 @@
       "function_text": "Wind alarm no. 1",
       "description": "",
       "device_address": "1.1.5",
+      "device_application": "M-0002_A-A066-14-550B",
       "channel": null,
       "dpts": [
         {
@@ -208,6 +215,7 @@
       "function_text": "Output value",
       "description": "2-byte generic",
       "device_address": "1.1.6",
+      "device_application": "M-0002_A-A01B-14-1B7C",
       "channel": null,
       "dpts": [],
       "object_size": "2 Bytes",
@@ -230,6 +238,7 @@
       "function_text": "Measured value outside range",
       "description": "1-bit undefined DPT",
       "device_address": "1.1.6",
+      "device_application": "M-0002_A-A01B-14-1B7C",
       "channel": null,
       "dpts": [
         {
@@ -257,6 +266,7 @@
       "function_text": "Output value",
       "description": "2-byte DPT 9 any",
       "device_address": "1.1.6",
+      "device_application": "M-0002_A-A01B-14-1B7C",
       "channel": null,
       "dpts": [
         {
@@ -378,6 +388,7 @@
       "function_text": "Output value",
       "description": "2-byte DPT 9 generic",
       "device_address": "1.1.6",
+      "device_application": "M-0002_A-A01B-14-1B7C",
       "channel": null,
       "dpts": [
         {
@@ -406,6 +417,7 @@
       "function_text": "Command value - Heating",
       "description": "",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -433,6 +445,7 @@
       "function_text": "Setpoint temperature - Active operating mode",
       "description": "",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -460,6 +473,7 @@
       "function_text": "Setpoint temperature - Active operating mode - Status",
       "description": "",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -487,6 +501,7 @@
       "function_text": "Room temperature - Measured value 1",
       "description": "",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": "MD-2_M-20_MI-1_CH-81",
       "dpts": [
         {
@@ -514,6 +529,7 @@
       "function_text": "Room temperature - Measured value 1",
       "description": "",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": "MD-2_M-4_MI-1_CH-81",
       "dpts": [
         {
@@ -541,6 +557,7 @@
       "function_text": "Temporary status indication",
       "description": "no-channel GO",
       "device_address": "1.1.7",
+      "device_application": "M-0008_A-20E0-21-9997-O000A",
       "channel": null,
       "dpts": [
         {
@@ -606,7 +623,7 @@
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.0",
-      "application_program": "M-0083_A-0139-22-F35B-O0072",
+      "application": "M-0083_A-0139-22-F35B-O0072",
       "project_uid": 25,
       "communication_object_ids": [],
       "channels": {}
@@ -617,7 +634,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.5",
-      "application_program": "M-0002_A-A066-14-550B",
+      "application": "M-0002_A-A066-14-550B",
       "project_uid": 31,
       "communication_object_ids": [
         "1.1.5/O-40_R-1433",
@@ -636,7 +653,7 @@
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.6",
-      "application_program": "M-0002_A-A01B-14-1B7C",
+      "application": "M-0002_A-A01B-14-1B7C",
       "project_uid": 49,
       "communication_object_ids": [
         "1.1.6/O-0_R-665",
@@ -652,7 +669,7 @@
       "description": "",
       "manufacturer_name": "GIRA Giersiepen",
       "individual_address": "1.1.7",
-      "application_program": "M-0008_A-20E0-21-9997-O000A",
+      "application": "M-0008_A-20E0-21-9997-O000A",
       "project_uid": 60,
       "communication_object_ids": [
         "1.1.7/MD-2_M-20_MI-1_O-2-2_R-3",

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -31,6 +31,7 @@ class CommunicationObject(TypedDict):
     function_text: str
     description: str
     device_address: str
+    device_application: str | None
     channel: str | None
     dpts: list[DPTType]
     object_size: str
@@ -46,7 +47,7 @@ class Device(TypedDict):
     description: str
     manufacturer_name: str
     individual_address: str
-    application_program: str | None
+    application: str | None
     project_uid: int | None
     communication_object_ids: list[str]
     channels: dict[str, Channel]  # id: Channel

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -32,11 +32,19 @@ class CommunicationObject(TypedDict):
     description: str
     device_address: str
     device_application: str | None
+    module: ModuleInstanceInfos | None
     channel: str | None
     dpts: list[DPTType]
     object_size: str
     group_address_links: list[str]
     flags: Flags
+
+
+class ModuleInstanceInfos(TypedDict):
+    """Information about module association for CommunicationObjects."""
+
+    definition: str
+    root_number: int  # `Number` assigned by ComObject - without Module base object number added
 
 
 class Device(TypedDict):

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -46,6 +46,7 @@ class Device(TypedDict):
     description: str
     manufacturer_name: str
     individual_address: str
+    application_program: str | None
     project_uid: int | None
     communication_object_ids: list[str]
     channels: dict[str, Channel]  # id: Channel

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -289,6 +289,7 @@ class XMLParser:
                     description=com_object.description or "",
                     device_address=device.individual_address,
                     device_application=device.application_program_ref,
+                    module_def=com_object.module,
                     channel=com_object.channel,
                     dpts=com_object.datapoint_types,
                     object_size=com_object.object_size,  # type: ignore[typeddict-item]

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -309,6 +309,7 @@ class XMLParser:
                 description=device.description,
                 manufacturer_name=device.manufacturer_name,
                 individual_address=device.individual_address,
+                application_program=device.application_program_ref,
                 project_uid=device.project_uid,
                 communication_object_ids=device_com_objects,
                 channels={

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -288,6 +288,7 @@ class XMLParser:
                     function_text=com_object.function_text,  # type: ignore[typeddict-item]
                     description=com_object.description or "",
                     device_address=device.individual_address,
+                    device_application=device.application_program_ref,
                     channel=com_object.channel,
                     dpts=com_object.datapoint_types,
                     object_size=com_object.object_size,  # type: ignore[typeddict-item]
@@ -309,7 +310,7 @@ class XMLParser:
                 description=device.description,
                 manufacturer_name=device.manufacturer_name,
                 individual_address=device.individual_address,
-                application_program=device.application_program_ref,
+                application=device.application_program_ref,
                 project_uid=device.project_uid,
                 communication_object_ids=device_com_objects,
                 channels={


### PR DESCRIPTION
- Add application program identifier to devices
- Add application program identifier and module information to communication objects

Communication objects with same application program, module definition and root number can probably be configured in the same way as they very likely represent similar values only for different channels or physical outlets.