### PR TITLE
Use ruff isort plugin instead of isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,13 @@ repos:
     hooks:
       - id: flake8
         files: ^(xknxproject|examples|docs)/.+\.py$
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args:
-          - --resolve-all-configs
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.0.292'
     hooks:
       - id: ruff
+        # in CI it is directly run by tox to allow dependency upgrade checks
+        stages: [pre-commit]
         args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,7 @@ version = {attr = "xknxproject.__version__.__version__"}
 include = ["xknxproject*"]
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312"]
 exclude = "generated"
-
-
-[tool.isort]
-profile = "black"
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-combine_as_imports = true
 
 
 [tool.mypy]
@@ -125,6 +117,7 @@ select = [
   "D",   # pydocstyle
   "E",   # pycodestyle
   "F",   # pyflakes
+  "I",   # isort
   "RUF", # ruff specific
   "T20", # print
   "UP",  # pyupgrade
@@ -139,3 +132,7 @@ ignore = [
 extend-exclude = [
   "script",
 ]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+combine-as-imports = true

--- a/requirements_testing.txt
+++ b/requirements_testing.txt
@@ -1,6 +1,5 @@
 -r requirements_production.txt
 pre-commit==3.5.0
-isort==5.12.0
 flake8==6.1.0
 pylint==3.0.2
 pytest==7.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, typing, lint, pylint
+envlist = py39, py310, py311, py312, ruff, typing, lint, pylint
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,12 +14,10 @@ wheel_build_env = .pkg
 [testenv:lint]
 basepython = python3
 commands =
-    ruff check {posargs:.}
     pre-commit run codespell {posargs: --all-files}
     pre-commit run flake8 {posargs: --all-files}
     pre-commit run pyupgrade {posargs: --all-files}
     pre-commit run black {posargs: --all-files}
-    pre-commit run isort {posargs: --all-files}
     pre-commit run check-json {posargs: --all-files}
     pre-commit run trailing-whitespace {posargs: --all-files}
 
@@ -27,6 +25,11 @@ commands =
 basepython = python3
 commands =
      pylint xknxproject
+
+[testenv:ruff]
+basepython = python3
+commands =
+    ruff check {posargs:.}
 
 [testenv:typing]
 basepython = python3


### PR DESCRIPTION
- Use ruff isort plugin instead of isort
- Move ruff to separate tox env (so dependabot updates can trigger a run - which doesn't work for `update pre-commit hoos` script)
- Run ruff in pre-commit only on `pre-commit`
- Remove isort from requirements
- Remove black +target_version` as it is now inferred from `project.requires-python`