### PR TITLE
Add order number to devices

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -244,6 +244,7 @@
     "1.1.1": {
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
+      "order_number": "AKH-0800.03",
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.1",
@@ -274,6 +275,7 @@
     "1.1.2": {
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "Heizungsaktor 8-fach",
+      "order_number": "AKH-0800.03",
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.2",

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -180,6 +180,7 @@
     "0.0.1": {
       "name": "AKS-2016.02 Switch Actuator 20-fold, 12TE, 16A",
       "hardware_name": "Schaltaktor 20-fach,12TE, 230VAC, 16A",
+      "order_number": "AKS-2016.02",
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "0.0.1",
@@ -195,6 +196,7 @@
     "0.0.2": {
       "name": "JRA/S4.230.5.1 Jal./Rol.Akt.Fahrzt.man.4f,230V,REG",
       "hardware_name": "JRA/S4.230.5.1 Jal./Rol.Akt.Fahrzt.man.4f,230V,REG",
+      "order_number": "2CDG 110 125 R0011",
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "0.0.2",

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -652,6 +652,7 @@
     "1.1.0": {
       "name": "SCN-IP100.03 IP Router with Secure",
       "hardware_name": "IP Router Secure",
+      "order_number": "SCN-IP100.03",
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.0",
@@ -663,6 +664,7 @@
     "1.1.5": {
       "name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "hardware_name": "JRA/S4.230.2.1 Jal./Rol.Akt.man.4f,230V,REG",
+      "order_number": "2CDG 110 121 R0011",
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.5",
@@ -682,6 +684,7 @@
     "1.1.6": {
       "name": "AE/S4.2 Analogue Input,4-fold,MDRC",
       "hardware_name": "AE/S4.2 Analogeingang,4fach,REG",
+      "order_number": "2CDG 110 030 R0011",
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.6",
@@ -698,6 +701,7 @@
     "1.1.7": {
       "name": "Heating actuator 6-gang with controller",
       "hardware_name": "Heizungsaktor 6fach mit Regler Secure",
+      "order_number": "2139 00",
       "description": "",
       "manufacturer_name": "GIRA Giersiepen",
       "individual_address": "1.1.7",

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -76,6 +76,7 @@ class HardwareLoader:
         return Product(
             identifier=product_node.get("Id", ""),
             text=product_node.get("Text", ""),
+            order_number=product_node.get("OrderNumber", ""),
         )
 
     @staticmethod

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -52,6 +52,7 @@ class Device(TypedDict):
 
     name: str
     hardware_name: str
+    order_number: str
     description: str
     manufacturer_name: str
     individual_address: str

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -160,6 +160,7 @@ class DeviceInstance:
         )
         self.product_name: str = ""
         self.hardware_name: str = ""
+        self.order_number: str = ""
         self.manufacturer_name: str = ""
 
     def add_additional_address(self, address: str) -> None:
@@ -488,6 +489,7 @@ class Product:
 
     identifier: str
     text: str
+    order_number: str
     hardware_name: str = ""
 
 

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -195,6 +195,7 @@ class XMLParser:
                 continue
             device.product_name = product.text
             device.hardware_name = product.hardware_name
+            device.order_number = product.order_number
 
             try:
                 application_program_ref = hardware_application_map[
@@ -308,6 +309,7 @@ class XMLParser:
             devices_dict[device.individual_address] = Device(
                 name=device.product_name,
                 hardware_name=device.hardware_name,
+                order_number=device.order_number,
                 description=device.description,
                 manufacturer_name=device.manufacturer_name,
                 individual_address=device.individual_address,


### PR DESCRIPTION
Add order number to devices for comparability of hardware product across different application versions.