### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = ["pyzipper>=0.3.6", "striprtf>=0.0.26"]
 description = "A library to gather information from ETS project files used for KNX"
 dynamic = ["version"]
 keywords = ["KNX", "ETS", "Home Assistant"]
-license = { text = "GPL-2.0-or-later" }
+license = { text = "GPL-2.0-only" }
 readme = "README.md"
 requires-python = ">=3.9.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = ["pyzipper>=0.3.6", "striprtf>=0.0.26"]
 description = "A library to gather information from ETS project files used for KNX"
 dynamic = ["version"]
 keywords = ["KNX", "ETS", "Home Assistant"]
-license = { file = "LICENSE" }
+license = { text = "GPL-2.0-or-later" }
 readme = "README.md"
 requires-python = ">=3.9.0"
 


### PR DESCRIPTION
Use the SPDX license identifier for ~`GPL-2.0-or-later`~ `GPL-2.0-only` instead of the whole license file inside the project metadata. This will make it easier to correctly identify the project license. See also [PEP-639](https://peps.python.org/pep-0639/) which is close to being finalized.

https://spdx.org/licenses/