### PR TITLE
Better error messages on StopIteration errors

### DIFF
--- a/xknxproject/exceptions/__init__.py
+++ b/xknxproject/exceptions/__init__.py
@@ -3,6 +3,7 @@
 from .exceptions import (
     InvalidPasswordException,
     ProjectNotFoundException,
+    UnexpectedDataError,
     UnexpectedFileContent,
     XknxProjectException,
 )
@@ -12,4 +13,5 @@ __all__ = [
     "InvalidPasswordException",
     "ProjectNotFoundException",
     "UnexpectedFileContent",
+    "UnexpectedDataError",
 ]

--- a/xknxproject/exceptions/exceptions.py
+++ b/xknxproject/exceptions/exceptions.py
@@ -15,3 +15,7 @@ class ProjectNotFoundException(XknxProjectException):
 
 class UnexpectedFileContent(XknxProjectException):
     """Unexpected file content."""
+
+
+class UnexpectedDataError(XknxProjectException):
+    """Unexpected data in project file."""

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from xml.etree import ElementTree
 
+from xknxproject.exceptions import UnexpectedDataError
 from xknxproject.models import (
     ChannelNode,
     ComObjectInstanceRef,
@@ -112,11 +113,16 @@ class ProjectLoader:
             )
 
             for group_address in function.group_addresses:
-                group_address.address = next(
-                    ga.address
-                    for ga in group_address_list
-                    if ga.identifier == group_address.ref_id
-                )
+                try:
+                    group_address.address = next(
+                        ga.address
+                        for ga in group_address_list
+                        if ga.identifier == group_address.ref_id
+                    )
+                except StopIteration:
+                    raise UnexpectedDataError(
+                        f"Group address {group_address.ref_id} referred in function not found"
+                    ) from None
 
         return (
             group_address_list,


### PR DESCRIPTION
This avoids `TypeError: StopIteration interacts badly with generators and cannot be raised into a Future` and provides (hopefully) actionable error messages.