### PR TITLE
Support ETS 4.1 project files

### DIFF
--- a/xknxproject/const.py
+++ b/xknxproject/const.py
@@ -5,7 +5,7 @@ from typing import Final
 ETS_6_SCHEMA_VERSION: Final = 21
 ETS_5_7_SCHEMA_VERSION: Final = 20
 ETS_5_6_SCHEMA_VERSION: Final = 14
-ETS_4_2_SCHEMA_VERSION: Final = 11
+ETS_4_2_SCHEMA_VERSION: Final = 11  # same for ETS 4.1
 
 
 MAIN_DPT: Final = "DPT"

--- a/xknxproject/zip/extractor.py
+++ b/xknxproject/zip/extractor.py
@@ -147,12 +147,15 @@ def _get_xml_namespace(project_zip: ZipFile) -> str:
     """Get the XML namespace of the project."""
     with project_zip.open("knx_master.xml", mode="r") as master:
         for line_number, line in enumerate(master, start=1):
-            if line_number == 2:
+            # ETS 4.1 has namespace in the first line, newer versions in second
+            if line_number in (1, 2):
                 try:
                     namespace_match = re.match(
                         r".+ xmlns=\"(.+?)\"",
                         line.decode(),
                     )
+                    if namespace_match is None and line_number == 1:
+                        continue
                     namespace = namespace_match.group(1)  # type: ignore[union-attr]
                     _LOGGER.debug("Namespace: %s", namespace)
                     return namespace
@@ -161,7 +164,7 @@ def _get_xml_namespace(project_zip: ZipFile) -> str:
                     raise UnexpectedFileContent(
                         "Could not parse XML namespace."
                     ) from None
-            if line_number > 2:
+            else:
                 break
         raise UnexpectedFileContent("Could not find XML namespace.")
 


### PR DESCRIPTION
ETS 4.1.6 (Build 3250) seems to use the same schema version as 4.1 (Version 11), but the `knx_master.xml` lacks the `<?xml version="1.0" encoding="UTF-8"?>` first line. So we have to check first and second line for the namespace (we skipped first line previously).