### PR TITLE
Correctly parse Schema 14 device links

### DIFF
--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from xml.etree import ElementTree
 
+from xknxproject.const import ETS_5_7_SCHEMA_VERSION
 from xknxproject.exceptions import UnexpectedDataError
 from xknxproject.models import (
     ChannelNode,
@@ -313,7 +314,7 @@ class _TopologyLoader:
         )
 
     @staticmethod
-    def __get_links_from_ets4(com_object: ElementTree.Element) -> list[str]:
+    def __get_links_from_schema_1x(com_object: ElementTree.Element) -> list[str]:
         # Check if "Connectors" is available. This will always fail for ETS5/6
         if (connectors := com_object.find("{*}Connectors")) is None:
             return []
@@ -327,8 +328,8 @@ class _TopologyLoader:
         ]
 
     @staticmethod
-    def __get_links_from_ets5(com_object: ElementTree.Element) -> list[str]:
-        # ETS5/6 uses a space-separated string of GA
+    def __get_links_from_schema_2x(com_object: ElementTree.Element) -> list[str]:
+        # ETS 5.7+ / 6 uses a space-separated string of GA
         links = com_object.get("Links")
 
         if links is None:
@@ -342,10 +343,10 @@ class _TopologyLoader:
     ) -> ComObjectInstanceRef | None:
         """Create ComObjectInstanceRef."""
 
-        if self.__knx_proj_contents.is_ets4_project():
-            links = self.__get_links_from_ets4(com_object)
+        if self.__knx_proj_contents.schema_version < ETS_5_7_SCHEMA_VERSION:
+            links = self.__get_links_from_schema_1x(com_object)
         else:
-            links = self.__get_links_from_ets5(com_object)
+            links = self.__get_links_from_schema_2x(com_object)
 
         if not links:
             return None

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -315,7 +315,7 @@ class _TopologyLoader:
 
     @staticmethod
     def __get_links_from_schema_1x(com_object: ElementTree.Element) -> list[str]:
-        # Check if "Connectors" is available. This will always fail for ETS5/6
+        # Check if "Connectors" is available. Schema version <= 14
         if (connectors := com_object.find("{*}Connectors")) is None:
             return []
 


### PR DESCRIPTION
Schema 14 doesn't use `Links` attribute in `ComObjectInstanceRef` - it uses ETS 4 style here. 
`Links` seem to be used in Schema versions 20+ 