### PR TITLE
Keep com object instances without group address links

### DIFF
--- a/test/xml/test_parser.py
+++ b/test/xml/test_parser.py
@@ -32,7 +32,11 @@ def test_parse_project_ets6() -> None:
     assert len(parser.areas[1].lines) == 2
     assert len(parser.areas[1].lines[1].devices) == 3
     assert len(parser.areas[1].lines[1].devices[0].additional_addresses) == 4
-    assert len(parser.areas[1].lines[1].devices[1].com_object_instance_refs) == 2
+    # All instantiated communication objects are exposed, including those with no
+    # group address links; the subset that carries links stays at 2.
+    _device = parser.areas[1].lines[1].devices[1]
+    assert len(_device.com_object_instance_refs) == 8
+    assert sum(bool(c.links) for c in _device.com_object_instance_refs) == 2
     assert parser.areas[1].lines[1].devices[0].manufacturer_name == "MDT technologies"
 
 

--- a/test/xml/test_parser.py
+++ b/test/xml/test_parser.py
@@ -36,7 +36,13 @@ def test_parse_project_ets6() -> None:
     # group address links; the subset that carries links stays at 2.
     _device = parser.areas[1].lines[1].devices[1]
     assert len(_device.com_object_instance_refs) == 8
+    _linkless = [c for c in _device.com_object_instance_refs if not c.links]
+    assert len(_linkless) == 6
     assert sum(bool(c.links) for c in _device.com_object_instance_refs) == 2
+    # The kept link-less objects are usable, not just present: each is merged from the
+    # application program (com object number and DPT), which is the point of keeping them.
+    assert all(c.number is not None for c in _linkless)
+    assert all(c.datapoint_types for c in _linkless)
     assert parser.areas[1].lines[1].devices[0].manufacturer_name == "MDT technologies"
 
 

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -255,11 +255,10 @@ class _TopologyLoader:
         ]
 
         com_obj_inst_refs = [
-            com_obj_inst_ref
+            self._create_com_object_instance(elem)
             for elem in device_element.findall(
                 "{*}ComObjectInstanceRefs/{*}ComObjectInstanceRef"
             )
-            if (com_obj_inst_ref := self._create_com_object_instance(elem)) is not None
         ]
 
         module_instances = [
@@ -340,16 +339,23 @@ class _TopologyLoader:
     def _create_com_object_instance(
         self,
         com_object: ElementTree.Element,
-    ) -> ComObjectInstanceRef | None:
-        """Create ComObjectInstanceRef."""
+    ) -> ComObjectInstanceRef:
+        """
+        Create ComObjectInstanceRef.
+
+        A ``ComObjectInstanceRef`` without group address links is still kept: it
+        is an instantiated communication object of the device (it appears in the
+        device's ``GroupObjectTree``) and carries the flags/DPT the device was
+        programmed with, which downstream consumers need to reconstruct the full
+        Group Object Table. The high-level ``KNXProject`` view still filters
+        link-less objects out of ``communication_objects`` (see ``_transform``),
+        so this does not change that output.
+        """
 
         if self.__knx_proj_contents.schema_version < ETS_5_7_SCHEMA_VERSION:
             links = self.__get_links_from_schema_1x(com_object)
         else:
             links = self.__get_links_from_schema_2x(com_object)
-
-        if not links:
-            return None
 
         return ComObjectInstanceRef(
             identifier=com_object.get("Id"),

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -384,7 +384,7 @@ class ComObjectInstanceRef:
     datapoint_types: list[DPTType]  # "DataPointType" - knx:IDREFS
     description: str | None  # "Description" - language dependent
     channel: str | None  # "ChannelId" - knx:IDREFS
-    links: list[str] | None  # "Links" - knx:RELIDREFS
+    links: list[str]  # "Links" - knx:RELIDREFS (always a list; empty when link-less)
 
     # resolved via Hardware.xml from the containing DeviceInstance
     application_program_id_prefix: str = (
@@ -430,10 +430,29 @@ class ComObjectInstanceRef:
                 self.identifier,
             )
             return
-        com_object_ref = application.com_object_refs[self.com_object_ref_id]
+        # A com object instance without group address links is kept (it is still an
+        # instantiated object of the device), but such an object can carry a RefId that
+        # does not resolve in the application program (module-instance stripping edge
+        # cases, template objects). Degrade to a warning instead of aborting the whole
+        # project parse: the object stays, only its merged application info is missing.
+        com_object_ref = application.com_object_refs.get(self.com_object_ref_id)
+        if com_object_ref is None:
+            _LOGGER.warning(
+                "ComObjectInstanceRef %s references unknown ComObjectRef %s",
+                self.identifier,
+                self.com_object_ref_id,
+            )
+            return
         self._merge_from_parent_object(com_object_ref, parameters=parameters)
 
-        com_object = application.com_objects[com_object_ref.ref_id]
+        com_object = application.com_objects.get(com_object_ref.ref_id)
+        if com_object is None:
+            _LOGGER.warning(
+                "ComObjectRef %s references unknown ComObject %s",
+                self.com_object_ref_id,
+                com_object_ref.ref_id,
+            )
+            return
         self._merge_from_parent_object(com_object, parameters=parameters)
 
     def _merge_from_parent_object(


### PR DESCRIPTION
_create_com_object_instance dropped every ComObjectInstanceRef that had no group address links. Such an object is still an instantiated communication object of the device - it appears in the device GroupObjectTree and carries the flags/DPT/size the device was programmed with. Downstream consumers that reconstruct the full Group Object Table (per-object flag bytes) need these link-less objects; without them the table cannot be rebuilt byte-accurately.

Keep them on DeviceInstance.com_object_instance_refs. The high-level KNXProject view is unchanged: _transform already filters link-less objects out of communication_objects, so only the low-level model gains the extra entries.

Updated test_parse_project_ets6 accordingly (device now exposes all 8 instantiated com objects; the linked subset stays at 2).