### PR TITLE
Fix CommunicationObject module key

### DIFF
--- a/test/test_knxproj.py
+++ b/test/test_knxproj.py
@@ -1,10 +1,25 @@
 """Test parsing ETS projects."""
 
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+
 import pytest
 
 from xknxproject import XKNXProj
+from xknxproject.models import KNXProject
+from xknxproject.models.knxproject import (
+    CommunicationObject,
+    Device,
+    Function,
+    GroupAddress,
+    GroupRange,
+    ProjectInfo,
+    Space,
+)
 
-from . import RESOURCES_PATH
+from . import RESOURCES_PATH, STUBS_PATH
 from .conftest import assert_stub
 
 # imported by the refresh_stubs helper script - therefore a constant
@@ -35,3 +50,41 @@ def test_parse_project(file_stem: str, password: str, language: str) -> None:
     )
     project = knxproj.parse()
     assert_stub(project, f"{file_stem}.json")
+
+
+@pytest.mark.parametrize("file_stem", [fixture[0] for fixture in PROJECT_FIXTURES])
+def test_stub_keys_match_typed_dicts(file_stem: str) -> None:
+    """
+    Test the parsed structures carry exactly the keys their types declare.
+
+    Comparing a parse against a stub cannot catch a key written under a name
+    the type doesn't declare - both sides come from the parser. Type checking
+    doesn't catch it either: a `# type: ignore` on any argument of a multi-line
+    TypedDict call suppresses the extra-key error of the whole call. Readers of
+    the declared name then silently get nothing.
+    """
+    with (STUBS_PATH / f"{file_stem}.json").open(encoding="utf-8") as stub_file:
+        stub = json.load(stub_file)
+
+    assert set(stub) == set(KNXProject.__annotations__)
+    assert set(stub["info"]) == set(ProjectInfo.__annotations__)
+    for section, model, nested_key in (
+        ("communication_objects", CommunicationObject, None),
+        ("devices", Device, None),
+        ("group_addresses", GroupAddress, None),
+        ("group_ranges", GroupRange, "group_ranges"),
+        ("locations", Space, "spaces"),
+        ("functions", Function, None),
+    ):
+        for item in _iter_items(stub[section], nested_key):
+            assert set(item) == set(model.__annotations__), (
+                f"`{section}` item does not match `{model.__name__}`"
+            )
+
+
+def _iter_items(section: dict, nested_key: str | None) -> Iterator[dict]:
+    """Yield the items of a section, descending into nested ones."""
+    for item in section.values():
+        yield item
+        if nested_key is not None:
+            yield from _iter_items(item[nested_key], nested_key)

--- a/test/test_mcp_tools.py
+++ b/test/test_mcp_tools.py
@@ -317,7 +317,7 @@ def _module_project() -> KNXProject:
             "description": "",
             "device_address": device,
             "device_application": None,
-            "module": module,
+            "module_def": module,
             "channel": channel,
             "dpts": [],
             "object_size": "1 Bit",

--- a/xknxproject/mcp/tools.py
+++ b/xknxproject/mcp/tools.py
@@ -131,7 +131,7 @@ def _summarize_comobj(comobj: CommunicationObject) -> CommunicationObjectSummary
         group_address_links=list(comobj["group_address_links"]),
         channel=comobj.get("channel"),
         dpas=list(comobj.get("dpas") or []),
-        module=_module_ref(comobj.get("module")),
+        module=_module_ref(comobj.get("module_def")),
     )
 
 
@@ -431,7 +431,7 @@ def _module_definitions(project: KNXProject, channel: Channel) -> set[str]:
     definitions: set[str] = set()
     for co_id in channel["communication_object_ids"]:
         comobj = project["communication_objects"].get(co_id)
-        module = comobj.get("module") if comobj is not None else None
+        module = comobj.get("module_def") if comobj is not None else None
         if module is not None:
             definitions.add(module["definition"])
     return definitions
@@ -446,7 +446,7 @@ def _alignment_key(comobj: CommunicationObject) -> str:
     dpas = comobj.get("dpas")
     if dpas:
         return dpas[0]
-    module = comobj.get("module")
+    module = comobj.get("module_def")
     if module is not None:
         return f"root:{module['root_number']}"
     return f"num:{comobj['number']}"

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -33,7 +33,7 @@ class CommunicationObject(TypedDict):
     description: str
     device_address: str
     device_application: str | None
-    module: ModuleInstanceInfos | None
+    module_def: ModuleInstanceInfos | None
     channel: str | None
     dpts: list[DPTType]
     object_size: str


### PR DESCRIPTION
The parser writes the module instance of a communication object as `module_def` ([`xml/parser.py`](https://github.com/XKNX/xknxproject/blob/main/xknxproject/xml/parser.py)), while `CommunicationObject` declares it as `module`. Both were introduced together in #320, so `module_def` is what every parse has produced since 3.5.0 — all four test stubs carry it, none carries `module`.

So this is a fix of the declaration, not of the output: the exported JSON does not change, and neither do projects already stored by consumers (e.g. Home Assistant's `knx_project.json`).

### What was broken

Everything reading the *declared* name got `None`:

- `_summarize_comobj()` never reported a module
- `_module_definitions()` always returned an empty set, so `match_module_definition` in `find_related_communication_objects` could never match a channel

The MCP test covering it passed because it builds its own communication object dict using the declared key instead of parser output.

### Why nothing caught it

A `# type: ignore` on *any* argument of a multi-line TypedDict call suppresses the extra-key error for the whole call. `CommunicationObject(...)` in the parser carries several legitimate `# type: ignore[typeddict-item]` comments (`name`, `number`, `text`, `function_text`, `object_size` are `str | None` on the source objects), so both the `Extra key "module_def"` and the `Missing key "module"` error were swallowed. Minimal repro:

```python
class T(TypedDict):
    a: str
    module: str | None

def bad() -> str | None: ...

T(a=bad(), module_def=None)                            # error: Extra key "module_def"
T(a=bad(), module_def=None)  # type: ignore[typeddict-item]   ← no error at all
```

The stub tests could not catch it either — a stub is compared against the parse it was generated from, so both sides agree on the wrong key.

### Added guard

`test_stub_keys_match_typed_dicts` compares the stub JSON keys against the declared `__annotations__` for every model. Verified it fails on all four fixtures when the bug is reintroduced.
