### PR TITLE
Add CI step measuring peak memory usage of parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,26 @@ jobs:
           path: .coverage
           include-hidden-files: true
 
+  memory:
+    name: Memory usage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements_production.txt
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_production.txt
+      - name: Measure peak memory usage of parsing
+        run: |
+          set -o pipefail
+          python3 -m script.memory_usage | tee -a "$GITHUB_STEP_SUMMARY"
+
   coverage:
     name: Process test coverage
     runs-on: ubuntu-latest

--- a/script/memory_usage.py
+++ b/script/memory_usage.py
@@ -1,0 +1,72 @@
+"""
+Measure the peak memory usage of parsing an ETS project file.
+
+Run from the project directory:
+    python3 -m script.memory_usage
+
+This is run in CI to notice changes that increase the memory demand drastically -
+eg. using `ElementTree.parse()` where `ElementTree.iterparse()` was used before.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import time
+import tracemalloc
+
+from xknxproject import XKNXProj
+
+# The test project holding the biggest application program file (~10 MB uncompressed)
+PROJECT_PATH = (
+    Path(__file__).parent.parent / "test" / "resources" / "smart_linking.knxproj"
+)
+PROJECT_PASSWORD = "test"
+PROJECT_LANGUAGE = "de-DE"
+
+# Peak memory limit in MiB. Baseline is ~8 MiB - reading `knx_master.xml` into a
+# full ElementTree accounts for most of it. Reading one of the application program
+# files that way would add >50 MiB on its own.
+DEFAULT_LIMIT = 24.0
+
+MIB = 1024 * 1024
+
+
+def main() -> int:
+    """Parse the project file and report the peak memory usage."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--limit",
+        type=float,
+        default=DEFAULT_LIMIT,
+        help=f"fail if the peak memory exceeds this many MiB (default: {DEFAULT_LIMIT})",
+    )
+    args = parser.parse_args()
+
+    knxproj = XKNXProj(PROJECT_PATH, PROJECT_PASSWORD, language=PROJECT_LANGUAGE)
+    tracemalloc.start()
+    _start = time.perf_counter()
+    knxproj.parse()
+    duration = time.perf_counter() - _start
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+
+    peak_mib = peak / MIB
+    print(f"### Memory usage of parsing `{PROJECT_PATH.name}`")
+    print()
+    print(f"- Peak memory: **{peak_mib:.1f} MiB** (limit {args.limit:.1f} MiB)")
+    print(f"- Parsing time: {duration:.2f} s")
+
+    if peak_mib > args.limit:
+        print()
+        print(
+            f"Peak memory exceeds the limit of {args.limit:.1f} MiB. "
+            "Either reduce the memory demand or raise the limit "
+            "in `script/memory_usage.py` deliberately."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds `script/memory_usage.py` and a `memory` job to the CI workflow that reports the peak memory usage of parsing an ETS project file.

The script parses the project under `tracemalloc` and prints the peak allocation to the job log and to the GitHub step summary, so the number is visible right on the run page:

```
### Memory usage of parsing `smart_linking.knxproj`

- Peak memory: **7.6 MiB** (limit 24.0 MiB)
- Parsing time: 0.63 s
```

It exits non-zero above the limit (currently 24 MiB), so changes that drastically increase the memory demand fail CI instead of going unnoticed.

## Why

Memory regressions in the parser are invisible today — swapping an `ElementTree.iterparse()` for a `parse()` costs an order of magnitude but keeps all tests green.

## Notes for review

**Choice of project file:** `smart_linking.knxproj` — not the biggest archive, but the one holding the biggest application program XML (`M-0064_A-5810-12-2E9D.xml`, 10.3 MB uncompressed), which is where `iterparse` actually matters. Measured peaks per fixture:

| fixture | peak |
| --- | --- |
| smart_linking | 7.6 MiB |
| testprojekt-ets6-* / ets6_* | 7.2 MiB |
| xknx_test_project | 6.9 MiB |
| module-definition-test | 6.9 MiB |

No bigger stub is needed: the baseline is dominated by `knx_master.xml` (7.4 MiB, loaded into a full ElementTree), while the application programs only cost ~2.5 MiB thanks to `iterparse`.

**Sensitivity verified:** replacing the `iterparse` in `application_program_loader.py` with a full `parse()` moves the peak from 7.6 MiB to 56.1 MiB and fails the check. The 24 MiB limit sits between baseline and regression with ~3x headroom.

**Baseline stability:** 8.5 MiB on 3.9/3.10, 7.5 MiB on 3.13, 7.6 MiB on 3.14 — spread is far smaller than the headroom.

The job runs on Python 3.13 and only needs `requirements_production.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)