### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py39-plus
+          - --py310-plus
           - --force
           - --keep-updates
         files: ^(xknxproject)/.+\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 keywords = ["KNX", "ETS", "Home Assistant"]
 license = "GPL-2.0-only"
 readme = "README.md"
-requires-python = ">=3.9.0"
+requires-python = ">=3.10.0"
 
 [project.urls]
 homepage = "https://github.com/XKNX/xknxproject"
@@ -33,7 +33,7 @@ include = ["xknxproject*"]
 
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 show_error_codes = true
 ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py39, py310, py311, py312, py313, ruff, typing, lint, pylint
+envlist = py310, py311, py312, py313, ruff, typing, lint, pylint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
## What

Raise the minimum supported Python version from 3.9 to 3.10.

- `requires-python = ">=3.10.0"` in `pyproject.toml` — this also raises ruff's inferred `target-version`
- `[tool.mypy] python_version = "3.10"`
- Remove `py39` from the tox `envlist` and the `gh-actions` mapping
- Remove `"3.9"` from the CI matrix
- `python-typing-update` pre-commit hook now runs with `--py310-plus`

## Why

Python 3.9 reached end-of-life in October 2025.

## Notes for reviewers

**No source changes were needed.** Every module already uses `from __future__ import annotations` with PEP 585/604 syntax — there are no leftover `Optional[...]`/`Dict[...]` annotations, no `sys.version_info` branches, and no 3.9 backport shims.

Verified locally:

- `ruff check .` and `ruff format --check .` (pinned 0.16.3) — clean; the raised target-version surfaced no new `UP` fixes
- `mypy` (pinned 1.19.1) at both `--python-version 3.9` and `--python-version 3.10` — no issues in 25 source files
- `pytest` — 103 passed

The two remaining `3.9` matches in the tree are unrelated: `pylint==3.3.9` in `requirements_testing.txt` and the `xknxproject_version` fixture string in `test/test_mcp_tools.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)