### PR TITLE
Fix mypy 2.x unused-ignore errors in ApplicationProgramLoader

### DIFF
--- a/xknxproject/loader/application_program_loader.py
+++ b/xknxproject/loader/application_program_loader.py
@@ -58,6 +58,9 @@ class ApplicationProgramLoader:
             str, ApplicationProgramChannel
         ] = {}  # {Id: ApplicationProgramChannel}
         allocators: dict[str, Allocator] = {}
+        # `iterparse` yields `Any` since the type depends on the requested events;
+        # with `events=("start",)` it is always an `Element`
+        elem: ElementTree.Element
 
         with application_program_path.open(mode="rb") as application_xml:
             tree_iterator = ElementTree.iterparse(application_xml, events=("start",))


### PR DESCRIPTION
## What

Declare `elem: ElementTree.Element` before the `iterparse` loop in `ApplicationProgramLoader.load()`.

## Why

mypy 2.x ships a typeshed where `ElementTree.iterparse()` returns `_IterParseIterator[Any]` — the yielded type depends on the requested `events`, so it is deliberately `Any` (e.g. `start-ns` yields a tuple, `comment` a string). Under mypy 1.19 it still resolved to `Element`.

As a result `elem` became `Any`, the whole parse loop went unchecked, and all 12 `type: ignore` comments in it were reported as errors:

```
xknxproject/loader/application_program_loader.py:81: error: Unused "type: ignore" comment  [unused-ignore]
...
Found 12 errors in 1 file (checked 25 source files)
```

This is what fails CI on #631 (mypy 1.19.1 → 2.3.1).

## Note for reviewers

The alternative — deleting the 12 ignores — would silently leave that loop unchecked and break again as soon as typeshed tightens the annotation. Declaring the variable keeps `elem.attrib.get(...)` type checked and the existing ignores justified; with `events=("start",)` the yielded value is always an `Element`.

Verified with both mypy 1.19.1 (current pin) and mypy 2.3.1: clean. `ruff check` / `ruff format --check` clean, 103 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)