### PR TITLE
feat: optionally parse ETS6 secure device info

### DIFF
--- a/test/xml/test_parser.py
+++ b/test/xml/test_parser.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
+from xml.etree import ElementTree
 
 import pytest
 
+from xknxproject.loader.project_loader import _TopologyLoader
+from xknxproject.models.models import XMLArea, XMLLine
 from xknxproject.xml.parser import XMLParser
-from xknxproject.zip import extract
+from xknxproject.zip import KNXProjContents, extract
 
 from .. import RESOURCES_PATH
 
@@ -15,6 +19,51 @@ xknx_test_project_protected_ets5 = RESOURCES_PATH / "xknx_test_project.knxproj"
 xknx_test_project_module_defs = RESOURCES_PATH / "module-definition-test.knxproj"
 xknx_test_project_ets5 = RESOURCES_PATH / "xknx_test_project_no_password.knxproj"
 xknx_test_project_protected_ets6 = RESOURCES_PATH / "testprojekt-ets6.knxproj"
+
+
+def test_secure_info_is_opt_in() -> None:
+    """Parse ETS6 security credentials only when explicitly requested."""
+    device_element = ElementTree.fromstring(
+        """
+        <DeviceInstance xmlns="http://knx.org/xml/project/23"
+            Id="P-1_DI-1" Address="1" Puid="1">
+          <Security DeviceAuthenticationCode="auth-code"
+              DeviceAuthenticationCodeHash="auth-hash"
+              DeviceManagementPassword="management-password"
+              DeviceManagementPasswordHash="management-hash"
+              ToolKey="tool-key" />
+          <BusInterfaces>
+            <BusInterface RefId="BI-1" Password="bus-password"
+                PasswordHash="bus-hash" />
+          </BusInterfaces>
+        </DeviceInstance>
+        """
+    )
+    area = XMLArea(0, "", None, [])
+    line = XMLLine(0, None, "", "", [], area)
+
+    project_contents = cast(KNXProjContents, None)
+    default_device = _TopologyLoader(project_contents)._create_device(
+        device_element, line
+    )
+    assert default_device is not None
+    assert default_device.secure_info is None
+
+    secure_device = _TopologyLoader(
+        project_contents, include_secure_info=True
+    )._create_device(device_element, line)
+    assert secure_device is not None
+    assert secure_device.secure_info is not None
+    assert secure_device.secure_info.device_authentication_code == "auth-code"
+    assert secure_device.secure_info.device_authentication_code_hash == "auth-hash"
+    assert secure_device.secure_info.device_management_password == "management-password"
+    assert (
+        secure_device.secure_info.device_management_password_hash == "management-hash"
+    )
+    assert secure_device.secure_info.tool_key == "tool-key"
+    assert secure_device.secure_info.bus_interfaces[0].ref_id == "BI-1"
+    assert secure_device.secure_info.bus_interfaces[0].password == "bus-password"
+    assert secure_device.secure_info.bus_interfaces[0].password_hash == "bus-hash"
 
 
 def test_parse_project_ets6() -> None:

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -18,12 +18,14 @@ from xknxproject.models import (
     ParameterInstanceRef,
     SpaceType,
     XMLArea,
+    XMLBusInterface,
     XMLFunction,
     XMLGroupAddress,
     XMLGroupAddressRef,
     XMLGroupRange,
     XMLLine,
     XMLProjectInformation,
+    XMLSecureInfo,
     XMLSpace,
 )
 from xknxproject.util import get_dpt_type, parse_dpt_types, parse_xml_flag
@@ -37,6 +39,7 @@ class ProjectLoader:
     def load(
         knx_proj_contents: KNXProjContents,
         knx_master_data: KNXMasterData,
+        include_secure_info: bool = False,
     ) -> tuple[
         list[XMLGroupAddress],
         list[XMLGroupRange],
@@ -78,7 +81,10 @@ class ProjectLoader:
                         ga_range_l1, project_info.group_address_style
                     )
                 )
-            topology_loader = _TopologyLoader(knx_proj_contents)
+            topology_loader = _TopologyLoader(
+                knx_proj_contents,
+                include_secure_info=include_secure_info,
+            )
             for topology_element in tree.findall(
                 "{*}Project/{*}Installations/{*}Installation/{*}Topology"
             ):
@@ -192,8 +198,13 @@ class _GroupAddressRangeLoader:
 class _TopologyLoader:
     """Load topology from KNX XML."""
 
-    def __init__(self, knx_proj_contents: KNXProjContents) -> None:
+    def __init__(
+        self,
+        knx_proj_contents: KNXProjContents,
+        include_secure_info: bool = False,
+    ) -> None:
         self.__knx_proj_contents = knx_proj_contents
+        self.__include_secure_info = include_secure_info
 
     def load(self, topology_element: ElementTree.Element) -> list[XMLArea]:
         """Load topology mappings."""
@@ -294,6 +305,36 @@ class _TopologyLoader:
                 value=param_instance_node.get("Value"),
             )
 
+        secure_info = None
+        if self.__include_secure_info:
+            security_element = device_element.find("{*}Security")
+            if security_element is not None:
+                secure_info = XMLSecureInfo(
+                    device_authentication_code=security_element.get(
+                        "DeviceAuthenticationCode", ""
+                    ),
+                    device_authentication_code_hash=security_element.get(
+                        "DeviceAuthenticationCodeHash", ""
+                    ),
+                    device_management_password=security_element.get(
+                        "DeviceManagementPassword", ""
+                    ),
+                    device_management_password_hash=security_element.get(
+                        "DeviceManagementPasswordHash", ""
+                    ),
+                    tool_key=security_element.get("ToolKey", ""),
+                    bus_interfaces=[
+                        XMLBusInterface(
+                            ref_id=bus_interface.get("RefId", ""),
+                            password=bus_interface.get("Password", ""),
+                            password_hash=bus_interface.get("PasswordHash", ""),
+                        )
+                        for bus_interface in device_element.findall(
+                            "{*}BusInterfaces/{*}BusInterface"
+                        )
+                    ],
+                )
+
         return DeviceInstance(
             identifier=device_element.get("Id", ""),
             address=int(address),
@@ -320,6 +361,7 @@ class _TopologyLoader:
             == "true",
             medium_config_loaded=device_element.get("MediumConfigLoaded") == "true",
             parameters_loaded=device_element.get("ParametersLoaded") == "true",
+            secure_info=secure_info,
         )
 
     @staticmethod

--- a/xknxproject/models/__init__.py
+++ b/xknxproject/models/__init__.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 from .knxproject import (
     Area,
+    BusInterface,
     Channel,
     CommunicationObject,
     Device,
@@ -15,6 +16,8 @@ from .knxproject import (
     KNXProject,
     Line,
     ProjectInfo,
+    SecureDevice,
+    SecureInfo,
     Space,
 )
 from .models import (
@@ -36,12 +39,14 @@ from .models import (
     Product,
     TranslationsType,
     XMLArea,
+    XMLBusInterface,
     XMLFunction,
     XMLGroupAddress,
     XMLGroupAddressRef,
     XMLGroupRange,
     XMLLine,
     XMLProjectInformation,
+    XMLSecureInfo,
     XMLSpace,
 )
 from .static import MEDIUM_TYPES, GroupAddressStyle, SpaceType

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -51,6 +51,24 @@ class ModuleInstanceInfos(TypedDict):
     )
 
 
+class BusInterface(TypedDict):
+    """Secure credentials associated with a device bus interface."""
+
+    password: str
+    password_hash: str
+
+
+class SecureInfo(TypedDict):
+    """Security credentials exported by ETS for a device."""
+
+    device_authentication_code: str
+    device_authentication_code_hash: str
+    device_management_password: str
+    device_management_password_hash: str
+    tool_key: str
+    bus_interfaces: dict[str, BusInterface]
+
+
 class Device(TypedDict):
     """Devices dictionary."""
 
@@ -71,6 +89,12 @@ class Device(TypedDict):
     communication_part_loaded: bool
     medium_config_loaded: bool
     parameters_loaded: bool
+
+
+class SecureDevice(Device):
+    """Device dictionary including opt-in ETS security information."""
+
+    secure_info: SecureInfo
 
 
 class Channel(TypedDict):

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -119,6 +119,27 @@ class XMLLine:
     area: XMLArea
 
 
+@dataclass
+class XMLBusInterface:
+    """Security credentials for one device bus interface."""
+
+    ref_id: str
+    password: str
+    password_hash: str
+
+
+@dataclass
+class XMLSecureInfo:
+    """Security credentials exported for a device."""
+
+    device_authentication_code: str
+    device_authentication_code_hash: str
+    device_management_password: str
+    device_management_password_hash: str
+    tool_key: str
+    bus_interfaces: list[XMLBusInterface]
+
+
 class DeviceInstance:
     """Class that represents a device instance."""
 
@@ -148,6 +169,7 @@ class DeviceInstance:
         communication_part_loaded: bool = False,
         medium_config_loaded: bool = False,
         parameters_loaded: bool = False,
+        secure_info: XMLSecureInfo | None = None,
     ) -> None:
         """Initialize a Device Instance."""
         self.identifier = identifier
@@ -179,6 +201,7 @@ class DeviceInstance:
         self.module_instances = module_instances
         self.com_objects = com_objects or []
         self.parameter_instance_refs = parameter_instance_refs
+        self.secure_info = secure_info
         self.application_program_ref: str | None = None
 
         self.individual_address = (

--- a/xknxproject/xknxproj.py
+++ b/xknxproject/xknxproj.py
@@ -29,8 +29,16 @@ class XKNXProj:
         self.password = password
         self.language = language
 
-    def parse(self, combine: bool = True) -> KNXProject:
-        """Parse the KNX project."""
+    def parse(
+        self,
+        combine: bool = True,
+        include_secure_info: bool = False,
+    ) -> KNXProject:
+        """
+        Parse the KNX project.
+
+        Secure device credentials are omitted unless explicitly requested.
+        """
         _LOGGER.info(
             'Xknxproject version %s parsing "%s" with%s password...',
             __version__,
@@ -39,7 +47,10 @@ class XKNXProj:
         )
         _start = time.time()
         with extract(self.path, self.password) as knx_project_content:
-            project = XMLParser(knx_project_content).parse(self.language)
+            project = XMLParser(knx_project_content).parse(
+                language=self.language,
+                include_secure_info=include_secure_info,
+            )
 
         if combine:
             project = combine_project(project)

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import html
 import logging
 from operator import attrgetter
+from typing import cast
 
 from striprtf.striprtf import rtf_to_text
 
@@ -19,6 +20,7 @@ from xknxproject.models import (
     MEDIUM_TYPES,
     ApplicationProgram,
     Area,
+    BusInterface,
     Channel,
     CommunicationObject,
     Device,
@@ -34,6 +36,8 @@ from xknxproject.models import (
     Line,
     Product,
     ProjectInfo,
+    SecureDevice,
+    SecureInfo,
     Space,
     XMLArea,
     XMLFunction,
@@ -140,13 +144,24 @@ class XMLParser:
         self.project_info: XMLProjectInformation
         self.functions: list[XMLFunction] = []
 
-    def parse(self, language: str | None = None) -> KNXProject:
+    def parse(
+        self,
+        language: str | None = None,
+        include_secure_info: bool = False,
+    ) -> KNXProject:
         """Parse ETS project."""
-        self._load(language=language)
+        self._load(
+            language=language,
+            include_secure_info=include_secure_info,
+        )
         self._sort()
         return self._transform()
 
-    def _load(self, language: str | None) -> None:
+    def _load(
+        self,
+        language: str | None,
+        include_secure_info: bool,
+    ) -> None:
         """Load XML files."""
         (
             knx_master_data,
@@ -167,6 +182,7 @@ class XMLParser:
         ) = ProjectLoader.load(
             knx_proj_contents=self.knx_proj_contents,
             knx_master_data=knx_master_data,
+            include_secure_info=include_secure_info,
         )
 
         products_dict: dict[str, Product] = {}
@@ -337,7 +353,7 @@ class XMLParser:
                 for channel in device.channels
             }
 
-            devices_dict[device.individual_address] = Device(
+            device_data = Device(
                 name=device.name or device.product_name,
                 hardware_name=device.product_name,
                 order_number=device.order_number,
@@ -356,6 +372,23 @@ class XMLParser:
                 medium_config_loaded=device.medium_config_loaded,
                 parameters_loaded=device.parameters_loaded,
             )
+            if device.secure_info is not None:
+                secure_device = cast(SecureDevice, device_data)
+                secure_device["secure_info"] = SecureInfo(
+                    device_authentication_code=device.secure_info.device_authentication_code,
+                    device_authentication_code_hash=device.secure_info.device_authentication_code_hash,
+                    device_management_password=device.secure_info.device_management_password,
+                    device_management_password_hash=device.secure_info.device_management_password_hash,
+                    tool_key=device.secure_info.tool_key,
+                    bus_interfaces={
+                        bus_interface.ref_id: BusInterface(
+                            password=bus_interface.password,
+                            password_hash=bus_interface.password_hash,
+                        )
+                        for bus_interface in device.secure_info.bus_interfaces
+                    },
+                )
+            devices_dict[device.individual_address] = device_data
 
         topology_dict: dict[str, Area] = {}
         for area in self.areas:


### PR DESCRIPTION
## Summary
- parse ETS6 device security credentials from `Security` and `BusInterfaces` XML elements
- expose them through typed `secure_info` device data
- keep credentials omitted by default; opt in with `parse(include_secure_info=True)`
- add regression coverage for both default omission and opt-in extraction

Closes #529

## Validation
- `pytest -q` — 104 passed
- `ruff check .` — passed
- `ruff format --check --diff .` — passed
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)` — passed
- `git diff --check` — passed
