### PR TITLE
fix: tolerate missing module instances

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1,0 +1,33 @@
+"""Test internal model behavior."""
+
+from __future__ import annotations
+
+from xknxproject.models import ApplicationProgram, ComObjectInstanceRef
+
+
+def test_missing_module_instance_is_non_fatal() -> None:
+    """Keep communication objects when their module instance is missing."""
+    com_object = ComObjectInstanceRef(
+        identifier="O-1",
+        ref_id="MD-2_M-22_MI-1_O-2-31_R-3",
+        text="Broken module reference",
+        function_text=None,
+        read_flag=None,
+        write_flag=None,
+        communication_flag=None,
+        transmit_flag=None,
+        update_flag=None,
+        read_on_init_flag=None,
+        datapoint_types=[],
+        description=None,
+        channel=None,
+        links=[],
+        base_number_argument_ref="ObjNumberBase",
+        number=12,
+    )
+    application = ApplicationProgram({}, {}, {}, {}, {}, {})
+
+    com_object.apply_module_base_number_argument([], application)
+
+    assert com_object.number == 12
+    assert com_object.module is None

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -598,10 +598,13 @@ class ComObjectInstanceRef:
                 if self.ref_id.startswith(f"{mi.identifier}_")
             )
         except StopIteration:
-            raise UnexpectedDataError(
-                f"ModuleInstance not found for ComObjectInstanceRef {self.ref_id=} {self.text=} "
-                f"of application {self.application_program_id_prefix}",
-            ) from None
+            _LOGGER.warning(
+                "ModuleInstance not found for ComObjectInstanceRef %s %s of application %s",
+                self.ref_id,
+                self.text,
+                self.application_program_id_prefix,
+            )
+            return
 
         com_object_number = self.number
         self.number += _parse_base_number_argument(


### PR DESCRIPTION
## Summary
- keep parsing when a communication object references a missing `ModuleInstance`
- preserve the communication object number and leave module metadata unset
- add regression coverage for malformed ETS module references

Closes #477

## Validation
- `pytest -q test/test_models.py`
- `ruff check .`
- `ruff format --check --diff .`
- `mypy xknxproject test/test_models.py`
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)`
- `git diff --check`
