### PR TITLE
fix: resolve module placeholders in communication objects

### DIFF
--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -568,7 +568,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-1_SM-1_O-3-0_R-1": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].energy",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].energy",
       "number": 263,
       "text": "[EM][IC1][Dev 1.1] Verbrauchte Energie",
       "function_text": "W·h",
@@ -601,7 +601,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-1_SM-1_O-3-1_R-2": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].power",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].power",
       "number": 264,
       "text": "[EM][IC1][Dev 1.1] Verbrauchte Leistung",
       "function_text": "W",
@@ -664,7 +664,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-1_SM-1_O-3-0_R-1": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].energy",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].energy",
       "number": 277,
       "text": "[EM][IC2][Dev 2.1] Verbrauchte Energie",
       "function_text": "W·h",
@@ -697,7 +697,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-2_SM-1_O-3-0_R-1": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].energy",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].energy",
       "number": 263,
       "text": "[EM][IC1][Dev 1.2] Verbrauchte Energie",
       "function_text": "W·h",
@@ -730,7 +730,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-2_SM-1_O-3-0_R-1": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].energy",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].energy",
       "number": 277,
       "text": "[EM][IC2][Dev 2.2] Verbrauchte Energie",
       "function_text": "W·h",
@@ -763,7 +763,7 @@
       "dpas": null
     },
     "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-2_SM-1_O-3-1_R-2": {
-      "name": "oEnMon.devicePage[{{EnMonPageNum}}][{{EnMonDevNameNum}}].power",
+      "name": "oEnMon.devicePage[0][MD-4_L-1].power",
       "number": 278,
       "text": "[EM][IC2][Dev 2.2] Verbrauchte Leistung",
       "function_text": "W",

--- a/test/xml/test_parser.py
+++ b/test/xml/test_parser.py
@@ -131,5 +131,10 @@ def test_parse_project_with_module_defs() -> None:
     assert len(parser.areas) == 2
     assert len(parser.areas[1].lines) == 2
     assert len(parser.areas[1].lines[1].devices) == 4
+    assert all(
+        "{{" not in (com_object.name or "")
+        for device in parser.devices
+        for com_object in device.com_object_instance_refs
+    )
 
     assert len(parser.devices) == 4

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -220,6 +220,7 @@ class DeviceInstance:
                 module_instances=self.module_instances,
                 application=application,
             )
+            com_instance.resolve_module_placeholders(self.module_instances)
 
         for channel in self.channels:
             channel.resolve_channel_attributes(
@@ -516,6 +517,43 @@ class ComObjectInstanceRef:
         # TODO: verify in xsd if ComObject could have Semantics containing dpas too
         if isinstance(com_object, ComObjectRef):
             self.dpas = com_object.semantics
+
+    def resolve_module_placeholders(
+        self,
+        module_instances: list[ModuleInstance],
+    ) -> None:
+        """Replace module placeholders with module instance argument values."""
+        if not (
+            self.ref_id.startswith("MD-")
+            and any(
+                value and "{{" in value
+                for value in (self.name, self.text, self.function_text)
+            )
+        ):
+            return
+
+        try:
+            module_instance = max(
+                (
+                    mi
+                    for mi in module_instances
+                    if self.ref_id.startswith(f"{mi.identifier}_")
+                ),
+                key=lambda mi: len(mi.identifier),
+            )
+        except ValueError:
+            module_instance_ref = self.ref_id.split("_O", maxsplit=1)[0]
+            raise UnexpectedDataError(
+                f"ModuleInstance '{module_instance_ref}' not found for "
+                f"ComObjectInstanceRef '{self.ref_id}' {self.text}"
+            ) from None
+
+        for argument in module_instance.arguments:
+            placeholder = "{{" + argument.name + "}}"
+            for attribute in ("name", "text", "function_text"):
+                value = getattr(self, attribute)
+                if value is not None:
+                    setattr(self, attribute, value.replace(placeholder, argument.value))
 
     def apply_module_base_number_argument(
         self,


### PR DESCRIPTION
## Summary
- resolve module-instance placeholders in communication-object names, texts, and function texts
- support nested module references by selecting the longest matching module prefix
- update module-definition fixture expectations and add regression coverage

Closes #445

## Validation
- `pytest -q` — 103 passed
- `pre-commit run --all-files` — passed, including mypy
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)` — passed
- `git diff --check` — passed
