### PR TITLE
fix: correct group address style error messages

### DIFF
--- a/test/test_group_address.py
+++ b/test/test_group_address.py
@@ -1,0 +1,27 @@
+"""Test internal model behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from xknxproject.models.models import XMLGroupAddress, XMLGroupRange
+
+
+@pytest.mark.parametrize(
+    ("formatter", "expected"),
+    [
+        (lambda: XMLGroupAddress.str_address(1, "invalid"), "GroupAddressStyle"),
+        (
+            lambda: XMLGroupRange("range", 1, 2, [], [], "", "invalid").str_address(),
+            "GroupAddressStyle",
+        ),
+    ],
+)
+def test_invalid_group_address_style_error(
+    formatter: Callable[[], object], expected: str
+) -> None:
+    """Explain which group-address style value is invalid."""
+    with pytest.raises(ValueError, match=expected):
+        formatter()

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -58,7 +58,7 @@ class XMLGroupAddress:
         if group_address_style == GroupAddressStyle.TWOLEVEL:
             sub = raw_address & 0b11111111111
             return f"{main}/{sub}"
-        raise ValueError(f"GroupAddressSyste '{group_address_style}' not supported!")
+        raise ValueError(f"GroupAddressStyle '{group_address_style}' not supported!")
 
     def __repr__(self) -> str:
         """Return string representation."""
@@ -94,7 +94,7 @@ class XMLGroupRange:
             if (self.range_end - self.range_start) >= 2046:
                 return start_address_token[0]
             return "/".join(start_address_token[0:2])
-        raise ValueError(f"GroupAddressSyste '{self.style}' not supported!")
+        raise ValueError(f"GroupAddressStyle '{self.style}' not supported!")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- correct the `GroupAddressStyle` typo in invalid-style errors
- cover both group-address and group-range formatting paths

## Validation
- `pytest -q` — 105 passed
- `pre-commit run --all-files` — passed, including mypy
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)` — passed
- `git diff --check` — passed
