### PR TITLE
fix: parse XML namespaces robustly

### DIFF
--- a/test/zip/test_extractor.py
+++ b/test/zip/test_extractor.py
@@ -1,16 +1,44 @@
 """Test reading KNX projects."""
 
+from io import BytesIO
+from zipfile import ZipFile
+
 from pytest import raises
 
-from xknxproject.exceptions import InvalidPasswordException
+from xknxproject.exceptions import InvalidPasswordException, UnexpectedFileContent
 from xknxproject.zip import extract
-from xknxproject.zip.extractor import _generate_ets6_zip_password
+from xknxproject.zip.extractor import (
+    _generate_ets6_zip_password,
+    _get_xml_namespace,
+)
 
 from .. import RESOURCES_PATH
 
 xknx_test_project_protected_ets5 = RESOURCES_PATH / "xknx_test_project.knxproj"
 xknx_test_project_ets5 = RESOURCES_PATH / "xknx_test_project_no_password.knxproj"
 xknx_test_project_protected_ets6 = RESOURCES_PATH / "testprojekt-ets6.knxproj"
+
+
+def test_namespace_can_be_declared_after_xml_declaration() -> None:
+    """Read namespaces regardless of their position in valid XML."""
+    archive = BytesIO()
+    with ZipFile(archive, "w") as project_zip:
+        project_zip.writestr(
+            "knx_master.xml",
+            "<?xml version='1.0'?>\n<KNX xmlns='http://knx.org/xml/project/23'></KNX>",
+        )
+    with ZipFile(BytesIO(archive.getvalue())) as project_zip:
+        assert _get_xml_namespace(project_zip) == "http://knx.org/xml/project/23"
+
+
+def test_malformed_namespace_xml_raises() -> None:
+    """Report malformed master XML as unexpected project content."""
+    archive = BytesIO()
+    with ZipFile(archive, "w") as project_zip:
+        project_zip.writestr("knx_master.xml", b"<KNX")
+    with ZipFile(BytesIO(archive.getvalue())) as project_zip:
+        with raises(UnexpectedFileContent, match="Could not parse XML namespace"):
+            _get_xml_namespace(project_zip)
 
 
 def test_extract_knx_project_ets5() -> None:

--- a/xknxproject/zip/extractor.py
+++ b/xknxproject/zip/extractor.py
@@ -8,8 +8,8 @@ from contextlib import contextmanager
 import hashlib
 import logging
 from pathlib import Path
-import re
 from typing import IO
+import xml.etree.ElementTree as ElementTree
 from zipfile import Path as ZipPath, ZipFile, ZipInfo
 
 import pyzipper
@@ -144,29 +144,21 @@ def _extract_protected_project_file(
 
 
 def _get_xml_namespace(project_zip: ZipFile) -> str:
-    """Get the XML namespace of the project."""
-    with project_zip.open("knx_master.xml", mode="r") as master:
-        for line_number, line in enumerate(master, start=1):
-            # ETS 4.1 has namespace in the first line, newer versions in second
-            if line_number in (1, 2):
-                try:
-                    namespace_match = re.match(
-                        r".+ xmlns=\"(.+?)\"",
-                        line.decode(),
-                    )
-                    if namespace_match is None and line_number == 1:
-                        continue
-                    namespace = namespace_match.group(1)  # type: ignore[union-attr]
-                    _LOGGER.debug("Namespace: %s", namespace)
-                    return namespace
-                except (AttributeError, IndexError, UnicodeDecodeError):
-                    _LOGGER.error("Could not parse XML namespace from %s", line)
-                    raise UnexpectedFileContent(
-                        "Could not parse XML namespace."
-                    ) from None
-            else:
-                break
-        raise UnexpectedFileContent("Could not find XML namespace.")
+    """Get the default XML namespace of the project."""
+    try:
+        with project_zip.open("knx_master.xml", mode="r") as master:
+            for _event, namespace in ElementTree.iterparse(
+                master, events=("start-ns",)
+            ):
+                prefix, uri = namespace
+                if prefix == "":
+                    _LOGGER.debug("Namespace: %s", uri)
+                    return str(uri)
+    except ElementTree.ParseError:
+        _LOGGER.exception("Could not parse XML namespace")
+        raise UnexpectedFileContent("Could not parse XML namespace.") from None
+
+    raise UnexpectedFileContent("Could not find XML namespace.")
 
 
 def _get_schema_version(namespace: str) -> int:


### PR DESCRIPTION
## Summary
- parse the default namespace from valid XML regardless of declaration line or quote style
- report malformed XML as `UnexpectedFileContent`
- add in-memory ZIP regression tests

## Validation
- `pytest -q` — 105 passed
- `pre-commit run --all-files` — passed, including mypy
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)` — passed
- `git diff --check` — passed
