### PR TITLE
fix: preserve protected archive open errors

### DIFF
--- a/test/zip/test_extractor.py
+++ b/test/zip/test_extractor.py
@@ -1,16 +1,32 @@
 """Test reading KNX projects."""
 
+from unittest.mock import Mock
+from zipfile import ZipFile
+
 from pytest import raises
 
 from xknxproject.exceptions import InvalidPasswordException
 from xknxproject.zip import extract
-from xknxproject.zip.extractor import _generate_ets6_zip_password
+from xknxproject.zip.extractor import (
+    _extract_protected_project_file,
+    _generate_ets6_zip_password,
+)
 
 from .. import RESOURCES_PATH
 
 xknx_test_project_protected_ets5 = RESOURCES_PATH / "xknx_test_project.knxproj"
 xknx_test_project_ets5 = RESOURCES_PATH / "xknx_test_project_no_password.knxproj"
 xknx_test_project_protected_ets6 = RESOURCES_PATH / "testprojekt-ets6.knxproj"
+
+
+def test_protected_archive_open_failure_preserves_error() -> None:
+    """Do not mask an archive stream open failure during cleanup."""
+    archive = Mock(spec=ZipFile)
+    archive.open.side_effect = OSError("archive stream unavailable")
+
+    with raises(OSError, match="archive stream unavailable"):
+        with _extract_protected_project_file(archive, Mock(), "test", 21):
+            pass
 
 
 def test_extract_knx_project_ets5() -> None:

--- a/xknxproject/zip/extractor.py
+++ b/xknxproject/zip/extractor.py
@@ -123,6 +123,7 @@ def _extract_protected_project_file(
     if not password:
         raise InvalidPasswordException("Password required.")
 
+    project_archive_file: IO[bytes] | None = None
     try:
         project_archive: ZipFile
         pwd: bytes
@@ -140,7 +141,8 @@ def _extract_protected_project_file(
         raise InvalidPasswordException("Invalid password.") from exception
     finally:
         _LOGGER.debug("Closed protected project archive")
-        project_archive_file.close()
+        if project_archive_file is not None:
+            project_archive_file.close()
 
 
 def _get_xml_namespace(project_zip: ZipFile) -> str:


### PR DESCRIPTION
## Summary
- safely clean up the nested protected-project stream when opening succeeds
- preserve the original archive-open exception when opening fails
- add regression coverage for the failure path

## Validation
- `pytest -q` — 104 passed
- `pre-commit run --all-files` — passed, including mypy
- `python3 -m py_compile $(find xknxproject test -name '*.py' -print)` — passed
- `git diff --check` — passed
