### PR TITLE
Expose full hardware attributes + coupler filter-table inputs

### DIFF
--- a/test/resources/stubs/ets6_free.json
+++ b/test/resources/stubs/ets6_free.json
@@ -21,7 +21,8 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -33,13 +34,15 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -54,6 +57,7 @@
       "project_uid": 12,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -66,6 +70,7 @@
       "project_uid": 14,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -78,6 +83,7 @@
       "project_uid": 16,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -90,6 +96,7 @@
       "project_uid": 21,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -104,6 +111,7 @@
         "1"
       ],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "2...128": {
           "name": "Group 1.1",
@@ -113,6 +121,7 @@
             "2"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {
             "3...33": {
               "name": "Group 1.1.1",
@@ -122,6 +131,7 @@
                 "3"
               ],
               "comment": "",
+              "unfiltered": false,
               "group_ranges": {}
             }
           }
@@ -134,6 +144,7 @@
       "address_end": 1024,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {}
     },
     "1025...1536": {
@@ -142,6 +153,7 @@
       "address_end": 1536,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "1025...1151": {
           "name": "Sub",
@@ -151,6 +163,7 @@
             "1025"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/test/resources/stubs/ets6_two_level.json
+++ b/test/resources/stubs/ets6_two_level.json
@@ -21,7 +21,8 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -33,19 +34,22 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "1st floor",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         },
         "2": {
           "name": "2nd floor",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -60,6 +64,7 @@
       "project_uid": 6,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -72,6 +77,7 @@
       "project_uid": 8,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -86,6 +92,7 @@
         "0/1"
       ],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {}
     },
     "1": {
@@ -96,6 +103,7 @@
         "1/1"
       ],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {}
     },
     "2": {
@@ -104,6 +112,7 @@
       "address_end": 6143,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {}
     }
   },

--- a/test/resources/stubs/module-definition-test.json
+++ b/test/resources/stubs/module-definition-test.json
@@ -805,7 +805,8 @@
           "name": "Bereichslinie",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -817,7 +818,8 @@
           "name": "Hauptlinie",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "Neue Linie",
@@ -828,7 +830,8 @@
             "1.1.3",
             "1.1.4"
           ],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -838,6 +841,32 @@
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "order_number": "AKH-0800.03",
+      "hardware_serial_number": "358",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 71.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": true,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "qENlB3WO3RN8Rg2JBTLbTncsSy4=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.1",
@@ -914,6 +943,32 @@
       "name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "hardware_name": "AKH-0800.03 Heizungsaktor 8-fach, 4TE, 24/230VAC",
       "order_number": "AKH-0800.03",
+      "hardware_serial_number": "358",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 71.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": true,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "qENlB3WO3RN8Rg2JBTLbTncsSy4=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {},
       "description": "Modules use ObjBaseNumber argument",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.2",
@@ -1011,6 +1066,32 @@
       "name": "DALI Control Pro64 Gateway",
       "hardware_name": "DALI Control Pro64 Gateway",
       "order_number": "SCN-DA641P.04S",
+      "hardware_serial_number": "191",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 72.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "M-00EF",
+      "visible_description": "DALI Control Pro64 Gateway",
+      "default_language": "en-US",
+      "hash": "8xpE6b503AjOIL811tjqkOxLIqE=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {},
       "description": "Modules use Allocators for ObjBaseNumber ",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.3",
@@ -1038,6 +1119,32 @@
       "name": "Z70 v2",
       "hardware_name": "Z70 v2",
       "order_number": "ZVIZ70V2",
+      "hardware_serial_number": "ZVIZ70V2",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": null,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "ZuZdCUC2W+cbI35UeQjtt1+rTds=",
+      "non_reg_relevant_data_version": 1,
+      "internal_description": "",
+      "attributes": {},
       "description": "SubModules with Allocators",
       "manufacturer_name": "Zennio",
       "individual_address": "1.1.4",
@@ -1105,6 +1212,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/MD-2_M-1_MI-1_O-2-1_R-1"
       ],
@@ -1122,6 +1230,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3"
       ],
@@ -1139,6 +1248,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/O-334_R-21"
       ],
@@ -1156,6 +1266,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/MD-2_M-2_MI-1_O-2-1_R-1"
       ],
@@ -1173,6 +1284,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3"
       ],
@@ -1190,6 +1302,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.2/MD-2_M-1_MI-1_O-2-2_R-3"
       ],
@@ -1207,6 +1320,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/O-24_R-966"
       ],
@@ -1224,6 +1338,7 @@
         "sub": 7
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-2_M-3_MI-2_O-2-1_R-11"
       ],
@@ -1241,6 +1356,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-2_M-3_MI-3_O-2-0_R-10"
       ],
@@ -1258,6 +1374,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-1_M-1_MI-1_O-2-0_R-7"
       ],
@@ -1275,6 +1392,7 @@
         "sub": 7
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-1_M-1_MI-4_O-2-1_R-8"
       ],
@@ -1292,6 +1410,7 @@
         "sub": 5
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-3_M-2_MI-2_O-2-4_R-5"
       ],
@@ -1309,6 +1428,7 @@
         "sub": 5
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.3/MD-3_M-2_MI-8_O-2-5_R-6"
       ],
@@ -1326,6 +1446,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.2/MD-2_M-1_MI-1_O-2-19_R-6"
       ],
@@ -1343,6 +1464,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.2/MD-2_M-5_MI-1_O-2-8_R-18"
       ],
@@ -1360,6 +1482,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.2/MD-2_M-6_MI-1_O-2-20_R-7"
       ],
@@ -1377,6 +1500,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.2/O-334_R-21"
       ],
@@ -1394,6 +1518,7 @@
         "sub": 10
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/O-256_R-36"
       ],
@@ -1411,6 +1536,7 @@
         "sub": 10
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-1_SM-1_O-3-0_R-1"
       ],
@@ -1428,6 +1554,7 @@
         "sub": 56
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-1_SM-1_O-3-1_R-2"
       ],
@@ -1445,6 +1572,7 @@
         "sub": 10
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-1_SM-1_M-1_MI-1-1-2_SM-1_O-3-0_R-1"
       ],
@@ -1462,6 +1590,7 @@
         "sub": 10
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-1_SM-1_O-3-0_R-1"
       ],
@@ -1479,6 +1608,7 @@
         "sub": 10
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-2_SM-1_O-3-0_R-1"
       ],
@@ -1496,6 +1626,7 @@
         "sub": 56
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.4/MD-4_M-15_MI-2_SM-1_M-1_MI-2-1-2_SM-1_O-3-1_R-2"
       ],
@@ -1513,6 +1644,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/MD-2_M-1_MI-1_O-2-2_R-3",
         "1.1.1/MD-2_M-2_MI-1_O-2-2_R-3",
@@ -1529,6 +1661,7 @@
       "address_end": 2047,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "0/0": {
           "name": "Wohnzimmer",
@@ -1540,6 +1673,7 @@
             "0/0/3"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "0/1": {
@@ -1551,6 +1685,7 @@
             "0/1/1"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "0/2": {
@@ -1561,6 +1696,7 @@
             "0/2/2"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "0/6": {
@@ -1588,6 +1724,7 @@
             "0/6/17"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "0/7": {
@@ -1598,6 +1735,7 @@
             "0/7/2"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }
@@ -1608,6 +1746,7 @@
       "address_end": 4095,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {}
     },
     "2": {
@@ -1616,6 +1755,7 @@
       "address_end": 6143,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "2/0": {
           "name": "Sub",
@@ -1623,6 +1763,7 @@
           "address_end": 4351,
           "group_addresses": [],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/test/resources/stubs/smart_linking.json
+++ b/test/resources/stubs/smart_linking.json
@@ -1202,7 +1202,8 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -1218,7 +1219,8 @@
             "1.0.1",
             "1.0.2"
           ],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "",
@@ -1228,7 +1230,8 @@
             "1.1.1",
             "1.1.2"
           ],
-          "medium_type": "KNX RF (RF)"
+          "medium_type": "KNX RF (RF)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -1238,6 +1241,35 @@
       "name": "KNX IP Router 752 secure",
       "hardware_name": "KNX IP Router 752 secure",
       "order_number": "KNX IP Router 752 secure",
+      "hardware_serial_number": "KNX IP Router 752 secure",
+      "version_number": 256,
+      "bus_current": 20.0,
+      "width_in_millimeter": 18.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": true,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": true,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": true,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "de-DE",
+      "hash": "Lf2yt8VN8MMxs1MjSp8K279mFp4=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {
+        "CatalogName": "KNX IP Router 752 secure",
+        "Colour": "grau"
+      },
       "description": "",
       "manufacturer_name": "Weinzierl Engineering GmbH",
       "individual_address": "1.0.0",
@@ -1257,6 +1289,32 @@
       "name": "AH3F16H-SEC Schaltaktor 3f",
       "hardware_name": "AH3F16H-SEC Schaltaktor 3f",
       "order_number": "79236-SEC",
+      "hardware_serial_number": "2036-10",
+      "version_number": 1,
+      "bus_current": 5.0,
+      "width_in_millimeter": 160.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": true,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "sFyZrJzUKz01IMLgx9ujzZuVUqY=",
+      "non_reg_relevant_data_version": 1,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "Lingg & Janke",
       "individual_address": "1.0.1",
@@ -1319,6 +1377,36 @@
       "name": "SpaceLogic KNX, Secure, Schalter/Jalousie 8-fach, Master",
       "hardware_name": "SpaceLogic KNX, Secure, Schalter/Jalousie 8-fach, Master",
       "order_number": "MTN6705-0008S",
+      "hardware_serial_number": "SpaceLogic KNX Switch Secure",
+      "version_number": 1,
+      "bus_current": 12.5,
+      "width_in_millimeter": 72.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "KTtkVpovfyBPM+wo9ASvgtVE6lU=",
+      "non_reg_relevant_data_version": 1,
+      "internal_description": "Internal Description (HW-Products)",
+      "attributes": {
+        "CatalogName": "Switch Blind Roller shutter actuator",
+        "Series": "",
+        "Colour": "white"
+      },
       "description": "",
       "manufacturer_name": "Schneider Electric Industries SAS",
       "individual_address": "1.0.2",
@@ -1442,6 +1530,32 @@
       "name": "KNX RF Multi/TP Medienkoppler",
       "hardware_name": "KNX RF Multi/TP Medienkoppler",
       "order_number": "3-0002-005",
+      "hardware_serial_number": "ISTPRFMK01",
+      "version_number": 1,
+      "bus_current": 8.0,
+      "width_in_millimeter": null,
+      "has_individual_address": true,
+      "has_application_program": false,
+      "is_coupler": true,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "Ready, Fast, Slow; Secure; Segment Coupler; SecurityProxy",
+      "default_language": "en-US",
+      "hash": "GPxgk4bywR8FwNIMMDibahxV6rw=",
+      "non_reg_relevant_data_version": 4,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "ise GmbH",
       "individual_address": "1.1.0",
@@ -1461,6 +1575,32 @@
       "name": "KNX RF+ Heizkörperthermostat mit Display und Longlife-Batterie, Secure",
       "hardware_name": "KNX RF+ Heizkörperthermostat mit Display und Longlife-Batterie, Secure",
       "order_number": "RF-HVA1DLB.01S",
+      "hardware_serial_number": "265",
+      "version_number": 1,
+      "bus_current": null,
+      "width_in_millimeter": null,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "LYHoldkEvFyaSZtmv+h2GPj/EKM=",
+      "non_reg_relevant_data_version": 1,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.1",
@@ -1506,6 +1646,32 @@
       "name": "KNX RF+ LED Controller CC/CV 60W / 230V 2-Kanäle, Secure",
       "hardware_name": "KNX RF+ LED Controller CC/CV 60W / 230V 2-Kanäle, Secure",
       "order_number": "RF-AKD260CC.02S",
+      "hardware_serial_number": "248",
+      "version_number": 1,
+      "bus_current": null,
+      "width_in_millimeter": null,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": true,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "PIsohcl4BAcVy8GtbI0SiltFfbQ=",
+      "non_reg_relevant_data_version": 1,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.2",
@@ -1555,6 +1721,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-0_R-1"
       ],
@@ -1572,6 +1739,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -1587,6 +1755,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "",
       "comment": ""
@@ -1602,6 +1771,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-20_R-88"
       ],
@@ -1619,6 +1789,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-21_R-90"
       ],
@@ -1636,6 +1807,7 @@
         "sub": 3
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-23_R-100"
       ],
@@ -1653,6 +1825,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-18_R-98"
       ],
@@ -1670,6 +1843,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-55_R-43"
       ],
@@ -1687,6 +1861,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-61_R-51"
       ],
@@ -1704,6 +1879,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-66_R-95"
       ],
@@ -1721,6 +1897,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-72_R-103"
       ],
@@ -1738,6 +1915,7 @@
         "sub": 8
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-77_R-121"
       ],
@@ -1755,6 +1933,7 @@
         "sub": 7
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-78_R-122"
       ],
@@ -1772,6 +1951,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-79_R-123"
       ],
@@ -1789,6 +1969,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-60_R-50",
         "1.0.2/O-89_R-131"
@@ -1807,6 +1988,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-92_R-133"
       ],
@@ -1824,6 +2006,7 @@
         "sub": 10
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-97_R-137"
       ],
@@ -1841,6 +2024,7 @@
         "sub": 8
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-98_R-138"
       ],
@@ -1858,6 +2042,7 @@
         "sub": 8
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-99_R-204"
       ],
@@ -1875,6 +2060,7 @@
         "sub": 7
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-100_R-205"
       ],
@@ -1892,6 +2078,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-101_R-206"
       ],
@@ -1909,6 +2096,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-102_R-207"
       ],
@@ -1926,6 +2114,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-114_R-218"
       ],
@@ -1943,6 +2132,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-115_R-219"
       ],
@@ -1960,6 +2150,7 @@
         "sub": 10
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-119_R-223"
       ],
@@ -1977,6 +2168,7 @@
         "sub": 8
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-120_R-224"
       ],
@@ -1994,6 +2186,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-121_R-238"
       ],
@@ -2011,6 +2204,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-127_R-246"
       ],
@@ -2028,6 +2222,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-132_R-290"
       ],
@@ -2045,6 +2240,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.2/O-138_R-298"
       ],
@@ -2062,6 +2258,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/O-2_R-11"
       ],
@@ -2079,6 +2276,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/O-3_R-12"
       ],
@@ -2096,6 +2294,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.1/O-4_R-7"
       ],
@@ -2113,6 +2312,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-9_R-85"
       ],
@@ -2130,6 +2330,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.0.1/O-11_R-70"
       ],
@@ -2144,6 +2345,7 @@
       "address_end": 2047,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "0/0": {
           "name": "Test Mitte",
@@ -2185,6 +2387,7 @@
             "0/0/33"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "0/1": {
@@ -2196,6 +2399,7 @@
             "0/1/1"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/test/resources/stubs/test_project-ets4.json
+++ b/test/resources/stubs/test_project-ets4.json
@@ -176,7 +176,8 @@
             "0.0.1",
             "0.0.2"
           ],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -186,6 +187,32 @@
       "name": "AKS-2016.02 Switch Actuator 20-fold, 12TE, 16A",
       "hardware_name": "AKS-2016.02 Switch Actuator 20-fold, 12TE, 16A",
       "order_number": "AKS-2016.02",
+      "hardware_serial_number": "19",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 209.8,
+      "has_individual_address": false,
+      "has_application_program": false,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "ZbW68lw4AZjvirG7b7kGyfy3CHU=",
+      "non_reg_relevant_data_version": 0,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "0.0.1",
@@ -209,6 +236,35 @@
       "name": "JRA/S4.230.5.1 Jal./Rol.Akt.Fahrzt.man.4f,230V,REG",
       "hardware_name": "JRA/S4.230.5.1 Jal./Rol.Akt.Fahrzt.man.4f,230V,REG",
       "order_number": "2CDG 110 125 R0011",
+      "hardware_serial_number": "2CDG 110 125 R0011",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 72.0,
+      "has_individual_address": false,
+      "has_application_program": false,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "q1bWjnuxYCXw3wbS2L0W0DwDMX8=",
+      "non_reg_relevant_data_version": 0,
+      "internal_description": "",
+      "attributes": {
+        "CatalogName": "Blind",
+        "Series": "ProM"
+      },
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "0.0.2",
@@ -240,6 +296,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "0.0.1/M-0083_A-0013-11-A9D6_O-0_R-10000",
         "0.0.2/M-0002_A-A061-14-BE27_O-10_R-485"
@@ -258,6 +315,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "0.0.1/M-0083_A-0013-11-A9D6_O-5_R-10005",
         "0.0.2/M-0002_A-A061-14-BE27_O-71_R-1506"
@@ -276,6 +334,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "0.0.1/M-0083_A-0013-11-A9D6_O-13_R-4",
         "0.0.2/M-0002_A-A061-14-BE27_O-10_R-485"
@@ -291,6 +350,7 @@
       "address_end": 2047,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "0/0": {
           "name": "Test 2nd level",
@@ -302,6 +362,7 @@
             "0/0/3"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/test/resources/stubs/testprojekt-ets6-functions.json
+++ b/test/resources/stubs/testprojekt-ets6-functions.json
@@ -21,7 +21,8 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -33,13 +34,15 @@
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "",
           "description": null,
           "devices": [],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -57,6 +60,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "Livingroom LivingroomLight",
       "comment": ""
@@ -72,6 +76,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "Livingroom LivingroomLight",
       "comment": ""
@@ -84,6 +89,7 @@
       "address_end": 2047,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "0/0": {
           "name": "Neue Mittelgruppe",
@@ -94,6 +100,7 @@
             "0/0/2"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/test/resources/stubs/xknx_test_project.json
+++ b/test/resources/stubs/xknx_test_project.json
@@ -637,7 +637,8 @@
           "name": "Bereichslinie",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         }
       }
     },
@@ -649,7 +650,8 @@
           "name": "Hauptlinie",
           "description": null,
           "devices": [],
-          "medium_type": "KNXnet/IP (IP)"
+          "medium_type": "KNXnet/IP (IP)",
+          "additional_group_addresses": []
         },
         "1": {
           "name": "Neue Linie",
@@ -660,7 +662,8 @@
             "1.1.6",
             "1.1.7"
           ],
-          "medium_type": "Twisted Pair (TP)"
+          "medium_type": "Twisted Pair (TP)",
+          "additional_group_addresses": []
         }
       }
     }
@@ -670,6 +673,32 @@
       "name": "SCN-IP100.03 IP Router with Secure",
       "hardware_name": "SCN-IP100.03 IP Router with Secure",
       "order_number": "SCN-IP100.03",
+      "hardware_serial_number": "136",
+      "version_number": 5,
+      "bus_current": 40.0,
+      "width_in_millimeter": 35.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": true,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": true,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "M-0072",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "tNXj9aJEmB8LuGH2VA1oBsmHogE=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "MDT technologies",
       "individual_address": "1.1.0",
@@ -689,6 +718,35 @@
       "name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "hardware_name": "JRA/S4.230.2.1 Blind/RollerShutterAct,M,4f,230V",
       "order_number": "2CDG 110 121 R0011",
+      "hardware_serial_number": "2CDG 110 121 R0011",
+      "version_number": 1,
+      "bus_current": 10.0,
+      "width_in_millimeter": 72.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "T9QqzBq0lxB9nspEV9EeHgmPaOc=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {
+        "CatalogName": "Blind",
+        "Series": "ProM"
+      },
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.5",
@@ -716,6 +774,34 @@
       "name": "AE/S4.2 Analogue Input,4-fold,MDRC",
       "hardware_name": "AE/S4.2 Analogue Input,4-fold,MDRC",
       "order_number": "2CDG 110 030 R0011",
+      "hardware_serial_number": "2CDG 110 030 R0011",
+      "version_number": 1,
+      "bus_current": null,
+      "width_in_millimeter": null,
+      "has_individual_address": false,
+      "has_application_program": false,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": false,
+      "has_application_program2": false,
+      "tp256": false,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "FobLXreEWGzo1YvggQRGs2VT8nY=",
+      "non_reg_relevant_data_version": 0,
+      "internal_description": "",
+      "attributes": {
+        "Series": "ab ETS2 V.1.2a"
+      },
       "description": "",
       "manufacturer_name": "ABB",
       "individual_address": "1.1.6",
@@ -740,6 +826,32 @@
       "name": "Custom name prefix - Heizungsaktor 6fach mit Regler",
       "hardware_name": "Heating actuator 6-gang with controller",
       "order_number": "2139 00",
+      "hardware_serial_number": "8 // 2139 00",
+      "version_number": 0,
+      "bus_current": 10.0,
+      "width_in_millimeter": 72.0,
+      "has_individual_address": true,
+      "has_application_program": true,
+      "is_coupler": false,
+      "is_power_supply": false,
+      "is_choke": false,
+      "is_power_line_repeater": false,
+      "is_power_line_signal_filter": false,
+      "is_cable": false,
+      "is_ip_enabled": false,
+      "is_rf_retransmitter": false,
+      "is_accessory": false,
+      "is_rail_mounted": true,
+      "has_application_program2": false,
+      "tp256": true,
+      "no_download_without_plugin": false,
+      "original_manufacturer": "M-000A",
+      "visible_description": "",
+      "default_language": "en-US",
+      "hash": "0ibXCVG2RTWlQzuzM3AvzEtWvCA=",
+      "non_reg_relevant_data_version": null,
+      "internal_description": "",
+      "attributes": {},
       "description": "",
       "manufacturer_name": "GIRA Giersiepen",
       "individual_address": "1.1.7",
@@ -908,6 +1020,7 @@
         "sub": 8
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-101_R-1578"
       ],
@@ -925,6 +1038,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-100_R-1577"
       ],
@@ -942,6 +1056,7 @@
         "sub": 8
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-71_R-1506"
       ],
@@ -959,6 +1074,7 @@
         "sub": 8
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-70_R-1505"
       ],
@@ -976,6 +1092,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-41_R-1434"
       ],
@@ -993,6 +1110,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-40_R-1433"
       ],
@@ -1010,6 +1128,7 @@
         "sub": 2
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.7/O-3_R-3"
       ],
@@ -1027,6 +1146,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.7/MD-2_M-4_MI-1_O-7-1_R-45"
       ],
@@ -1044,6 +1164,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.5/O-4_R-1417"
       ],
@@ -1058,6 +1179,7 @@
       "project_uid": 43,
       "dpt": null,
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "no dpt",
       "comment": ""
@@ -1073,6 +1195,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [],
       "description": "temperature",
       "comment": ""
@@ -1088,6 +1211,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.6/O-20_R-8108"
       ],
@@ -1105,6 +1229,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.6/O-9_R-9073"
       ],
@@ -1122,6 +1247,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.6/O-0_R-665",
         "1.1.6/O-9_R-9073"
@@ -1140,6 +1266,7 @@
         "sub": null
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.6/O-9_R-9073",
         "1.1.6/O-18_R-7994"
@@ -1158,6 +1285,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.7/MD-2_M-20_MI-1_O-5-10_R-18"
       ],
@@ -1175,6 +1303,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.7/MD-2_M-20_MI-1_O-5-0_R-17"
       ],
@@ -1192,6 +1321,7 @@
         "sub": 1
       },
       "data_secure": true,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.7/MD-2_M-20_MI-1_O-2-2_R-3"
       ],
@@ -1209,6 +1339,7 @@
         "sub": 1
       },
       "data_secure": false,
+      "unfiltered": false,
       "communication_object_ids": [
         "1.1.6/O-18_R-7994",
         "1.1.7/MD-2_M-20_MI-1_O-7-1_R-45"
@@ -1224,6 +1355,7 @@
       "address_end": 4095,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "1/0": {
           "name": "Neue Mittelgruppe",
@@ -1238,6 +1370,7 @@
             "1/0/5"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }
@@ -1248,6 +1381,7 @@
       "address_end": 6143,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "2/0": {
           "name": "Neue Mittelgruppe",
@@ -1259,6 +1393,7 @@
             "2/0/0"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "2/1": {
@@ -1274,6 +1409,7 @@
             "2/1/10"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }
@@ -1284,6 +1420,7 @@
       "address_end": 16383,
       "group_addresses": [],
       "comment": "",
+      "unfiltered": false,
       "group_ranges": {
         "7/0": {
           "name": "Non-DS",
@@ -1293,6 +1430,7 @@
             "7/0/0"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         },
         "7/1": {
@@ -1305,6 +1443,7 @@
             "7/1/2"
           ],
           "comment": "",
+          "unfiltered": false,
           "group_ranges": {}
         }
       }

--- a/xknxproject/loader/hardware_loader.py
+++ b/xknxproject/loader/hardware_loader.py
@@ -9,6 +9,19 @@ from xknxproject.models import HardwareToPrograms, Product
 from xknxproject.zip import KNXProjContents
 
 
+def _flag(node: ElementTree.Element, attr: str) -> bool:
+    """Read a knx:Bool_t attribute (default false)."""
+    return node.get(attr, "false") == "true"
+
+
+def _opt_int(value: str | None) -> int | None:
+    return int(value) if value not in (None, "") else None
+
+
+def _opt_float(value: str | None) -> float | None:
+    return float(value) if value not in (None, "") else None
+
+
 class HardwareLoader:
     """Load hardware from KNX XML."""
 
@@ -56,9 +69,37 @@ class HardwareLoader:
         hardware_programs: HardwareToPrograms = {}
 
         hardware_name: str = hardware_node.get("Name", "")
+        # Hardware-level attributes (identity + capability flags) apply to every product of this
+        # hardware, so they are copied onto each Product below.
+        hardware_attributes: dict[str, object] = {
+            "hardware_name": hardware_name,
+            "hardware_serial_number": hardware_node.get("SerialNumber", ""),
+            "version_number": _opt_int(hardware_node.get("VersionNumber")),
+            "bus_current": _opt_float(hardware_node.get("BusCurrent")),
+            "has_individual_address": _flag(hardware_node, "HasIndividualAddress"),
+            "has_application_program": _flag(hardware_node, "HasApplicationProgram"),
+            "has_application_program2": _flag(hardware_node, "HasApplicationProgram2"),
+            "tp256": _flag(hardware_node, "Tp256"),
+            "original_manufacturer": hardware_node.get("OriginalManufacturer", ""),
+            "no_download_without_plugin": _flag(
+                hardware_node, "NoDownloadWithoutPlugin"
+            ),
+            "is_coupler": _flag(hardware_node, "IsCoupler"),
+            "is_power_supply": _flag(hardware_node, "IsPowerSupply"),
+            "is_choke": _flag(hardware_node, "IsChoke"),
+            "is_power_line_repeater": _flag(hardware_node, "IsPowerLineRepeater"),
+            "is_power_line_signal_filter": _flag(
+                hardware_node, "IsPowerLineSignalFilter"
+            ),
+            "is_cable": _flag(hardware_node, "IsCable"),
+            "is_ip_enabled": _flag(hardware_node, "IsIPEnabled"),
+            "is_rf_retransmitter": _flag(hardware_node, "IsRFRetransmitter"),
+            "is_accessory": _flag(hardware_node, "IsAccessory"),
+        }
         for product_node in hardware_node.findall("{*}Products/{*}Product"):
             _product = HardwareLoader.parse_product_element(product_node)
-            _product.hardware_name = hardware_name
+            for attr, value in hardware_attributes.items():
+                setattr(_product, attr, value)
             product_dict[_product.identifier] = _product
 
         for product_node in hardware_node.findall(
@@ -74,10 +115,25 @@ class HardwareLoader:
     @staticmethod
     def parse_product_element(product_node: ElementTree.Element) -> Product:
         """Parse product mapping."""
+        attributes = {
+            name: attribute_node.get("Value", "")
+            for attribute_node in product_node.findall("{*}Attributes/{*}Attribute")
+            if (name := attribute_node.get("Name"))
+        }
         return Product(
             identifier=product_node.get("Id", ""),
             text=product_node.get("Text", ""),
             order_number=product_node.get("OrderNumber", ""),
+            is_rail_mounted=_flag(product_node, "IsRailMounted"),
+            width_in_millimeter=_opt_float(product_node.get("WidthInMillimeter")),
+            visible_description=product_node.get("VisibleDescription", ""),
+            default_language=product_node.get("DefaultLanguage", ""),
+            hash=product_node.get("Hash", ""),
+            non_reg_relevant_data_version=_opt_int(
+                product_node.get("NonRegRelevantDataVersion")
+            ),
+            internal_description=product_node.get("InternalDescription", ""),
+            attributes=attributes,
         )
 
     @staticmethod

--- a/xknxproject/loader/project_loader.py
+++ b/xknxproject/loader/project_loader.py
@@ -156,6 +156,7 @@ class _GroupAddressLoader:
             data_secure_key=group_address_element.get("Key"),
             comment=group_address_element.get("Comment", ""),
             style=group_address_style,
+            unfiltered=group_address_element.get("Unfiltered", "false") == "true",
         )
 
 
@@ -184,6 +185,7 @@ class _GroupAddressRangeLoader:
                 group_ranges=group_ranges,
                 comment=elem.get("Comment", ""),
                 style=group_address_style,
+                unfiltered=elem.get("Unfiltered", "false") == "true",
             )
 
         return create_xml_group_range(group_range_element)
@@ -226,7 +228,24 @@ class _TopologyLoader:
             medium_type = segment.get("MediumTypeRefId", "")
         else:
             medium_type = line_element.get("MediumTypeRefId", "")
-        line: XMLLine = XMLLine(address, description, name, medium_type, [], area)
+        # A coupler's manually added pass-through group addresses live on the segment (newer
+        # schemas, which nest a Segment under the line) or directly on the line (older schemas) as
+        # <AdditionalGroupAddresses><GroupAddress Address="..."/>.
+        container = segment if segment is not None else line_element
+        additional_group_addresses = [
+            int(addr)
+            for e in container.findall("{*}AdditionalGroupAddresses/{*}GroupAddress")
+            if (addr := e.get("Address")) is not None
+        ]
+        line: XMLLine = XMLLine(
+            address,
+            description,
+            name,
+            medium_type,
+            [],
+            area,
+            additional_group_addresses,
+        )
 
         for device_element in line_element.findall(".//{*}DeviceInstance"):
             if device := self._create_device(device_element, line):

--- a/xknxproject/models/knxproject.py
+++ b/xknxproject/models/knxproject.py
@@ -57,6 +57,32 @@ class Device(TypedDict):
     name: str
     hardware_name: str
     order_number: str
+    hardware_serial_number: str
+    version_number: int | None
+    bus_current: float | None
+    width_in_millimeter: float | None
+    has_individual_address: bool
+    has_application_program: bool
+    is_coupler: bool
+    is_power_supply: bool
+    is_choke: bool
+    is_power_line_repeater: bool
+    is_power_line_signal_filter: bool
+    is_cable: bool
+    is_ip_enabled: bool
+    is_rf_retransmitter: bool
+    is_accessory: bool
+    is_rail_mounted: bool
+    has_application_program2: bool
+    tp256: bool
+    no_download_without_plugin: bool
+    original_manufacturer: str
+    visible_description: str
+    default_language: str
+    hash: str
+    non_reg_relevant_data_version: int | None
+    internal_description: str
+    attributes: dict[str, str]
     description: str
     manufacturer_name: str
     individual_address: str
@@ -89,6 +115,7 @@ class Line(TypedDict):
     medium_type: str
     description: str | None
     devices: list[str]
+    additional_group_addresses: list[str]
 
 
 class Area(TypedDict):
@@ -109,6 +136,7 @@ class GroupAddress(TypedDict):
     project_uid: int | None
     dpt: DPTType | None
     data_secure: bool
+    unfiltered: bool
     communication_object_ids: list[str]
     description: str
     comment: str
@@ -121,6 +149,7 @@ class GroupRange(TypedDict):
     address_start: int
     address_end: int
     comment: str
+    unfiltered: bool
     group_addresses: list[str]
     group_ranges: dict[str, GroupRange]
 

--- a/xknxproject/models/models.py
+++ b/xknxproject/models/models.py
@@ -32,6 +32,7 @@ class XMLGroupAddress:
         data_secure_key: str | None,
         comment: str,
         style: GroupAddressStyle,
+        unfiltered: bool = False,
     ) -> None:
         """Initialize a group address."""
         self.name = name
@@ -43,6 +44,9 @@ class XMLGroupAddress:
         self.data_secure_key = data_secure_key  # Key as base64 encoded string or None
         self.comment = comment
         self.style = style
+        # The knxproj "Unfiltered" attribute: a group address (or its range) so marked is passed
+        # through line/backbone couplers unconditionally, independent of the crossing-link check.
+        self.unfiltered = unfiltered
         self.address = XMLGroupAddress.str_address(self.raw_address, self.style)
 
     @staticmethod
@@ -78,6 +82,8 @@ class XMLGroupRange:
     group_ranges: list[XMLGroupRange]
     comment: str
     style: GroupAddressStyle
+    # A whole range marked "route regardless": couplers pass every address in it unconditionally.
+    unfiltered: bool = False
 
     def str_address(self) -> str:
         """Generate a string representation for the range."""
@@ -117,6 +123,9 @@ class XMLLine:
     medium_type: str
     devices: list[DeviceInstance]
     area: XMLArea
+    # Raw group-address values manually added to a coupler on this line/segment as unconditional
+    # pass-through entries (the knxproj <Segment><AdditionalGroupAddresses><GroupAddress Address/>).
+    additional_group_addresses: list[int] = field(default_factory=list)
 
 
 class DeviceInstance:
@@ -187,6 +196,33 @@ class DeviceInstance:
         self.product_name: str = ""  # translatable name for specific product
         self.hardware_name: str = ""  # untranslatable name from hardware.xml
         self.order_number: str = ""
+        # hardware.xml identity + capability attributes (set during product merge)
+        self.hardware_serial_number: str = ""
+        self.version_number: int | None = None
+        self.bus_current: float | None = None  # mA
+        self.width_in_millimeter: float | None = None
+        self.has_individual_address: bool = False
+        self.has_application_program: bool = False
+        self.has_application_program2: bool = False
+        self.is_coupler: bool = False
+        self.is_power_supply: bool = False
+        self.is_choke: bool = False
+        self.is_power_line_repeater: bool = False
+        self.is_power_line_signal_filter: bool = False
+        self.is_cable: bool = False
+        self.is_ip_enabled: bool = False
+        self.is_rf_retransmitter: bool = False
+        self.is_accessory: bool = False
+        self.is_rail_mounted: bool = False
+        self.tp256: bool = False
+        self.no_download_without_plugin: bool = False
+        self.original_manufacturer: str = ""
+        self.visible_description: str = ""
+        self.default_language: str = ""
+        self.hash: str = ""
+        self.non_reg_relevant_data_version: int | None = None
+        self.internal_description: str = ""
+        self.attributes: dict[str, str] = {}
         self.manufacturer_name: str = ""
 
     def add_additional_address(self, address: str) -> None:
@@ -911,6 +947,34 @@ class Product:
     text: str
     order_number: str
     hardware_name: str = ""
+    # Product-level attributes (hardware.xml <Product>)
+    is_rail_mounted: bool = False
+    width_in_millimeter: float | None = None
+    visible_description: str = ""
+    default_language: str = ""
+    hash: str = ""
+    non_reg_relevant_data_version: int | None = None
+    internal_description: str = ""
+    attributes: dict[str, str] = field(default_factory=dict)  # <Attributes> Name->Value
+    # Hardware-level attributes (hardware.xml <Hardware>), copied onto every product of the hardware
+    hardware_serial_number: str = ""
+    version_number: int | None = None
+    bus_current: float | None = None  # mA
+    has_individual_address: bool = False
+    has_application_program: bool = False
+    has_application_program2: bool = False
+    is_coupler: bool = False  # device carries a coupler group-address filter table
+    is_power_supply: bool = False
+    is_choke: bool = False
+    is_power_line_repeater: bool = False
+    is_power_line_signal_filter: bool = False
+    is_cable: bool = False
+    is_ip_enabled: bool = False
+    is_rf_retransmitter: bool = False
+    is_accessory: bool = False
+    tp256: bool = False  # BCU memory model marker
+    original_manufacturer: str = ""
+    no_download_without_plugin: bool = False
 
 
 HardwareToPrograms = dict[str, str]

--- a/xknxproject/xml/parser.py
+++ b/xknxproject/xml/parser.py
@@ -115,6 +115,7 @@ def _recursive_convert_group_range(
             comment=html.unescape(
                 rtf_to_text(group_range.comment),  # type: ignore[no-untyped-call]
             ),
+            unfiltered=group_range.unfiltered,
             group_ranges=_recursive_convert_group_range(
                 group_range.group_ranges,
                 group_address_style,
@@ -201,6 +202,36 @@ class XMLParser:
             device.product_name = product.text
             device.hardware_name = product.hardware_name
             device.order_number = product.order_number
+            # hardware.xml identity + capability attributes (same names on Product and device)
+            for _hw_attr in (
+                "hardware_serial_number",
+                "version_number",
+                "bus_current",
+                "width_in_millimeter",
+                "has_individual_address",
+                "has_application_program",
+                "is_coupler",
+                "is_power_supply",
+                "is_choke",
+                "is_power_line_repeater",
+                "is_power_line_signal_filter",
+                "is_cable",
+                "is_ip_enabled",
+                "is_rf_retransmitter",
+                "is_accessory",
+                "is_rail_mounted",
+                "has_application_program2",
+                "tp256",
+                "no_download_without_plugin",
+                "original_manufacturer",
+                "visible_description",
+                "default_language",
+                "hash",
+                "non_reg_relevant_data_version",
+                "internal_description",
+                "attributes",
+            ):
+                setattr(device, _hw_attr, getattr(product, _hw_attr))
 
             try:
                 application_program_ref = hardware_application_map[
@@ -341,6 +372,32 @@ class XMLParser:
                 name=device.name or device.product_name,
                 hardware_name=device.product_name,
                 order_number=device.order_number,
+                hardware_serial_number=device.hardware_serial_number,
+                version_number=device.version_number,
+                bus_current=device.bus_current,
+                width_in_millimeter=device.width_in_millimeter,
+                has_individual_address=device.has_individual_address,
+                has_application_program=device.has_application_program,
+                is_coupler=device.is_coupler,
+                is_power_supply=device.is_power_supply,
+                is_choke=device.is_choke,
+                is_power_line_repeater=device.is_power_line_repeater,
+                is_power_line_signal_filter=device.is_power_line_signal_filter,
+                is_cable=device.is_cable,
+                is_ip_enabled=device.is_ip_enabled,
+                is_rf_retransmitter=device.is_rf_retransmitter,
+                is_accessory=device.is_accessory,
+                is_rail_mounted=device.is_rail_mounted,
+                has_application_program2=device.has_application_program2,
+                tp256=device.tp256,
+                no_download_without_plugin=device.no_download_without_plugin,
+                original_manufacturer=device.original_manufacturer,
+                visible_description=device.visible_description,
+                default_language=device.default_language,
+                hash=device.hash,
+                non_reg_relevant_data_version=device.non_reg_relevant_data_version,
+                internal_description=device.internal_description,
+                attributes=device.attributes,
                 description=device.description,
                 manufacturer_name=device.manufacturer_name,
                 individual_address=device.individual_address,
@@ -369,6 +426,12 @@ class XMLParser:
                     description=line.description,
                     devices=devices_topology,
                     medium_type=MEDIUM_TYPES.get(line.medium_type, "Unknown"),
+                    additional_group_addresses=[
+                        XMLGroupAddress.str_address(
+                            ga, self.project_info.group_address_style
+                        )
+                        for ga in line.additional_group_addresses
+                    ],
                 )
             topology_dict[str(area.address)] = Area(
                 name=area.name, description=area.description, lines=lines_dict
@@ -383,6 +446,7 @@ class XMLParser:
                 project_uid=group_address.project_uid,
                 dpt=group_address.dpt,
                 data_secure=bool(group_address.data_secure_key),
+                unfiltered=group_address.unfiltered,
                 communication_object_ids=[
                     com_object_id
                     for com_object_id, com_object in communication_objects.items()


### PR DESCRIPTION
The knxproj parse dropped hardware.xml device attributes and the coupler filter-table inputs. Consumers could not tell a coupler from a sensor, read its ratings/capabilities, or compute a coupler filter table. Expose on Device:

- Capabilities: is_coupler, is_power_supply, is_choke, is_power_line_repeater, is_power_line_signal_filter, is_cable, is_ip_enabled, is_rf_retransmitter, is_accessory, is_rail_mounted, has_individual_address, has_application_program, has_application_program2, tp256, no_download_without_plugin.
- Identity/ratings: hardware_serial_number, version_number, bus_current (mA), width_in_millimeter, original_manufacturer, default_language, hash, non_reg_relevant_data_version, internal_description, visible_description, attributes (product <Attributes> Name->Value).

Filter-table routing inputs:
- GroupAddress.unfiltered / GroupRange.unfiltered (knxproj "Unfiltered").
- Line.additional_group_addresses (knxproj <Segment><AdditionalGroupAddresses>).

Not included: <Baggages> (binary attachments) and <RegistrationInfo> (a registration-metadata element); and the scalar Semantics tag string, left out for now. Threaded through model, loaders, output dict and TypedDicts; stubs refreshed.